### PR TITLE
Fix timestamp for dataless instances

### DIFF
--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -96,7 +96,7 @@ export interface IInstance {
 }
 
 export interface IInstanceStatus {
-  archived: Date;
+  archived?: Date;
   isArchived: boolean;
   substatus: ISubstatus;
 }

--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -96,6 +96,8 @@ export interface IInstance {
 }
 
 export interface IInstanceStatus {
+  archived: Date;
+  isArchived: boolean;
   substatus: ISubstatus;
 }
 

--- a/src/frontend/src/utils/receipt.ts
+++ b/src/frontend/src/utils/receipt.ts
@@ -30,9 +30,11 @@ export const getInstanceMetaDataObject = (
   }
 
   let dateSubmitted;
-  if (instance.data) {
+  if (instance.data && instance.data.length > 0) {
     const lastChanged = getCurrentTaskData(application, instance).lastChanged;
     dateSubmitted = moment(lastChanged).format('DD.MM.YYYY / HH:mm');
+  } else if (instance.status.isArchived) {
+    dateSubmitted = moment(instance.status.archived).format('DD.MM.YYYY / HH:mm');
   }
 
   obj[getLanguageFromKey('receipt_platform.date_sent', language)] =

--- a/src/frontend/src/utils/receipt.ts
+++ b/src/frontend/src/utils/receipt.ts
@@ -31,9 +31,14 @@ export const getInstanceMetaDataObject = (
 
   let dateSubmitted;
   if (instance.data && instance.data.length > 0) {
-    const lastChanged = getCurrentTaskData(application, instance).lastChanged;
-    dateSubmitted = moment(lastChanged).format('DD.MM.YYYY / HH:mm');
-  } else if (instance.status.isArchived) {
+    let currentTaskData = getCurrentTaskData(application, instance);
+    if (currentTaskData !== undefined) {
+      const lastChanged = getCurrentTaskData(application, instance).lastChanged;
+      dateSubmitted = moment(lastChanged).format('DD.MM.YYYY / HH:mm');
+    }
+  }
+
+  if (dateSubmitted === undefined && instance.status.isArchived) {
     dateSubmitted = moment(instance.status.archived).format('DD.MM.YYYY / HH:mm');
   }
 

--- a/src/frontend/testConfig/apiResponses.ts
+++ b/src/frontend/testConfig/apiResponses.ts
@@ -75,6 +75,8 @@ export const instance: IExtendedInstance = {
       endEvent: null,
     },
     status: {
+      archived: null,
+      isArchived: false,
       substatus: null,
     },
     data: [
@@ -144,6 +146,8 @@ export const instanceWithSubstatus: IExtendedInstance = {
   instance: {
     ...instance.instance,
     status: {
+      archived: null,
+      isArchived: false,
       substatus: {
         label: 'Substatus label',
         description: 'Substatus description',


### PR DESCRIPTION
Changes:
- Prevent empty array access
- Fallback to archived timestamp for submittet time.<!--- Provide a general summary of your changes in the Title above -->

## Description
Have reproduced it locally with an app where
- all the datatypes have `"appLogic": { "autoDeleteOnProcessEnd": true },` and
- the application has `"autoDeleteOnProcessEnd": false`

The error message locally was: `Uncaught typeerror applicationMetaDataUtils_1.getCurrentTaskData is undefined`

The problem is that the code that attempts to find the timestamp for when it was submitted only checks that the instance.data array exists, but it will attempt to access a member even if length is 0. This is fixed by simply checking the array length.

## Related Issue(s)
- #53 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
