### PR TITLE
Accept react nodes in header title

### DIFF
--- a/src/frontend/src/components/molecules/AltinnCollapsibleAttachments.tsx
+++ b/src/frontend/src/components/molecules/AltinnCollapsibleAttachments.tsx
@@ -44,7 +44,8 @@ export function AltinnCollapsibleAttachments(props: IAltinnCollapsibleAttachment
     setOpen(!open);
   }
 
-  const attachmentCount = props.hideCount ? '' : `(${props.attachments && props.attachments.length})`;
+  const attachmentCount = props.hideCount == true ? ''
+    : Array.isArray(props.attachments) ? '(' + props.attachments.length + ')' : '(0)';
 
   return(
     <>

--- a/src/frontend/src/components/molecules/AltinnCollapsibleAttachments.tsx
+++ b/src/frontend/src/components/molecules/AltinnCollapsibleAttachments.tsx
@@ -69,7 +69,7 @@ export function AltinnCollapsibleAttachments(props: IAltinnCollapsibleAttachment
               />
             </ListItemIcon>
             <ListItemText
-              primary={`${props.title} ${attachmentCount}`}
+              primary={<>{props.title} {attachmentCount}</>}
               classes={{
                 root: classNames(props.classes.listItemTextPadding),
                 primary: classNames(props.classes.collapsedTitle),


### PR DESCRIPTION
Avoid string interpolation on ReactNodes, use fragment instead of string interpolation.

