### PR TITLE
Removed Microsoft.AspNet.WebApi.Client #GCPActive

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Also use an app for creating data that should be presented in receipt.
 
 ##### Manual
 
-- Open `src/backend/Views/Altinn.Receipt/receipt.cshtml` and change the `link` and `script` tags according to the comments in that file.
+- Open `src/backend/Altinn.Receipt/Views/Receipt/receipt.cshtml` and change the `link` and `script` tags according to the comments in that file.
 - Open a terminal in `src/backend/Altinn.Receipt`
 - Execute `dotnet run` and keep the process running
 

--- a/src/backend/Altinn.Receipt/Altinn.Platform.Receipt.csproj
+++ b/src/backend/Altinn.Receipt/Altinn.Platform.Receipt.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/src/backend/Altinn.Receipt/Altinn.Platform.Receipt.csproj
+++ b/src/backend/Altinn.Receipt/Altinn.Platform.Receipt.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/src/backend/Altinn.Receipt/Helpers/JsonSerializerOptionsProvider.cs
+++ b/src/backend/Altinn.Receipt/Helpers/JsonSerializerOptionsProvider.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Altinn.Platform.Receipt.Helpers;
+
+/// <summary>
+/// Provider class for JsonSerializerOptions
+/// </summary>
+public static class JsonSerializerOptionsProvider
+{
+    /// <summary>
+    /// Standard serializer options
+    /// </summary>
+    public static JsonSerializerOptions Options { get; } = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString,
+        
+        Converters = { new JsonStringEnumConverter() }
+    };
+}

--- a/src/backend/Altinn.Receipt/Services/ProfileWrapper.cs
+++ b/src/backend/Altinn.Receipt/Services/ProfileWrapper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text.Json;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 using Altinn.Common.AccessTokenClient.Services;
@@ -49,9 +49,7 @@ namespace Altinn.Platform.Receipt.Services.Interfaces
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                string responseString = await response.Content.ReadAsStringAsync();
-                UserProfile profile = JsonSerializer.Deserialize<UserProfile>(responseString, JsonSerializerOptionsProvider.Options);
-                return profile;
+                return await response.Content.ReadFromJsonAsync<UserProfile>(JsonSerializerOptionsProvider.Options);             
             }
 
             throw new PlatformHttpException(response, string.Empty);

--- a/src/backend/Altinn.Receipt/Services/RegisterWrapper.cs
+++ b/src/backend/Altinn.Receipt/Services/RegisterWrapper.cs
@@ -1,14 +1,16 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Threading.Tasks;
+
 using Altinn.Common.AccessTokenClient.Services;
-using Altinn.Platform.Receipt.Clients;
 using Altinn.Platform.Receipt.Configuration;
 using Altinn.Platform.Receipt.Extensions;
 using Altinn.Platform.Receipt.Helpers;
 using Altinn.Platform.Receipt.Services.Interfaces;
 using Altinn.Platform.Register.Models;
+
 using AltinnCore.Authentication.Utils;
 
 using Microsoft.AspNetCore.Http;
@@ -23,7 +25,6 @@ namespace Altinn.Platform.Receipt.Services
     {
         private readonly HttpClient _client;
         private readonly IHttpContextAccessor _contextaccessor;
-        private readonly PlatformSettings _platformSettings;
         private readonly IAccessTokenGenerator _accessTokenGenerator;
 
         /// <summary>
@@ -31,9 +32,8 @@ namespace Altinn.Platform.Receipt.Services
         /// </summary>
         public RegisterWrapper(HttpClient httpClient, IHttpContextAccessor httpContextAccessor, IOptions<PlatformSettings> platformSettings, IAccessTokenGenerator accessTokenGenerator)
         {
-            _platformSettings = platformSettings.Value;
-            httpClient.BaseAddress = new Uri(_platformSettings.ApiRegisterEndpoint);
-            httpClient.DefaultRequestHeaders.Add(_platformSettings.SubscriptionKeyHeaderName, _platformSettings.SubscriptionKey);
+            httpClient.BaseAddress = new Uri(platformSettings.Value.ApiRegisterEndpoint);
+            httpClient.DefaultRequestHeaders.Add(platformSettings.Value.SubscriptionKeyHeaderName, platformSettings.Value.SubscriptionKey);
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _client = httpClient;
             _contextaccessor = httpContextAccessor;
@@ -50,7 +50,8 @@ namespace Altinn.Platform.Receipt.Services
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                Party party = await response.Content.ReadAsAsync<Party>();
+                string responseString = await response.Content.ReadAsStringAsync();
+                Party party = JsonSerializer.Deserialize<Party>(responseString, JsonSerializerOptionsProvider.Options);
                 return party;
             }
 

--- a/src/backend/Altinn.Receipt/Services/RegisterWrapper.cs
+++ b/src/backend/Altinn.Receipt/Services/RegisterWrapper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text.Json;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 using Altinn.Common.AccessTokenClient.Services;
@@ -50,9 +50,7 @@ namespace Altinn.Platform.Receipt.Services
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                string responseString = await response.Content.ReadAsStringAsync();
-                Party party = JsonSerializer.Deserialize<Party>(responseString, JsonSerializerOptionsProvider.Options);
-                return party;
+                return await response.Content.ReadFromJsonAsync<Party>(JsonSerializerOptionsProvider.Options);
             }
 
             throw new PlatformHttpException(response, string.Empty);

--- a/src/backend/Altinn.Receipt/Services/StorageWrapper.cs
+++ b/src/backend/Altinn.Receipt/Services/StorageWrapper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text.Json;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Receipt.Configuration;
@@ -47,9 +47,7 @@ namespace Altinn.Platform.Receipt.Services.Interfaces
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                string responseString = await response.Content.ReadAsStringAsync();
-                Instance instance = JsonSerializer.Deserialize<Instance>(responseString, JsonSerializerOptionsProvider.Options);
-                return instance;
+                return await response.Content.ReadFromJsonAsync<Instance>(JsonSerializerOptionsProvider.Options);
             }
 
             throw new PlatformHttpException(response, string.Empty);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove use of Microsoft.AspNet.WebApi.Client.
Introduced global JsonSerializerOptions provider to be shared among the classes. 

## Related Issue(s)
- #74

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
