### PR TITLE
#151 Chained async call and language order fixed

### DIFF
--- a/src/frontend/src/language/languages.ts
+++ b/src/frontend/src/language/languages.ts
@@ -3,9 +3,9 @@ import { en } from './texts/en';
 import { nn } from './texts/nn';
 
 export const languageLookup: Record<string, Record<string, Record<string, string>>> = {
-  'en': en,
   'nb': nb,
   'nn': nn,
+  'en': en,
 };
 
 export const getLanguageFromCode = (languageCode: string, defaultLang: string = 'nb'): Record<string, Record<string, string>> => {


### PR DESCRIPTION
Chained async call as only the next one should be called when the first one fails of throws error.

## Description
Chained async call as only the next one should be called when the first one fails of throws error.

## Related Issue(s)
- #250
- #251
- #151

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] All tests run green
