### PR TITLE
#259 Receipt should choose language from `altinnPersistentContext` cookie

### DIFF
--- a/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
+++ b/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
@@ -88,14 +88,32 @@ namespace Altinn.Platform.Receipt
                 int userId = int.Parse(userIdString);
                 UserProfile profile = await _profile.GetUser(userId);
 
-                if (!string.IsNullOrEmpty(profile?.ProfileSettingPreference?.Language))
+                return Ok(profile);
+            }
+            catch (PlatformHttpException e)
+            {
+                return HandlePlatformHttpException(e);
+            }
+        }
+
+        /// <summary>
+        /// Gets the language from cookie for current user
+        /// </summary>
+        /// <returns>The language or 404(if not found)</returns>
+        [HttpGet]
+        [Route("receipt/api/v1/users/current/language")]
+        public IActionResult GetCurrentUserLanguage()
+        {
+            string language = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(_httpContextAccessor.HttpContext.Request.Cookies["altinnPersistentContext"]);
+
+            try
+            {
+                if (string.IsNullOrEmpty(language))
                 {
-                    profile.ProfileSettingPreference.Language = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(
-                        _httpContextAccessor.HttpContext.Request.Cookies["altinnPersistentContext"],
-                        profile.ProfileSettingPreference.Language);
+                    return NoContent();
                 }
 
-                return Ok(profile);
+                return Ok(new { language });
             }
             catch (PlatformHttpException e)
             {

--- a/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
+++ b/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
@@ -167,17 +167,22 @@ namespace Altinn.Platform.Receipt
                 return dafaultLang;
             }
 
-            switch (cookieValue)
+            if (cookieValue.Contains("UL=1033"))
             {
-                case string val when val.Contains("UL=1033"):
-                    return "en";
-                case string val when val.Contains("UL=1044"):
-                    return "nb";
-                case string val when val.Contains("UL=2068"):
-                    return "nn";
-                default:
-                    return dafaultLang;
+                return "en";
             }
+
+            if (cookieValue.Contains("UL=1044"))
+            {
+                return "nb";
+            }
+
+            if (cookieValue.Contains("UL=2068"))
+            {
+                return "nn";
+            }
+            
+            return dafaultLang;
         }
     }
 }

--- a/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
+++ b/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
@@ -90,7 +90,7 @@ namespace Altinn.Platform.Receipt
 
                 if (!string.IsNullOrEmpty(profile?.ProfileSettingPreference?.Language))
                 {
-                    profile.ProfileSettingPreference.Language = GetLanguageFromAltinnPersistenceCookie(
+                    profile.ProfileSettingPreference.Language = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(
                         _httpContextAccessor.HttpContext.Request.Cookies["altinnPersistentContext"],
                         profile.ProfileSettingPreference.Language);
                 }
@@ -158,37 +158,6 @@ namespace Altinn.Platform.Receipt
             {
                 return StatusCode(500, e.Message);
             }
-        }
-
-        /// <summary>
-        /// Gets the language from the Altinn persistence cookie.
-        /// </summary>
-        /// <param name="cookieValue">The value of the Altinn persistence cookie containing language information.</param>
-        /// <param name="defaultLang">The default language to return if the cookie is not found or doesn't contain language information.</param>
-        /// <returns>The language code ('en', 'nb', 'nn') extracted from the Altinn persistence cookie, or the default language if not found.</returns>
-        internal string GetLanguageFromAltinnPersistenceCookie(string cookieValue, string defaultLang = "nb")
-        {
-            if (cookieValue == null)
-            {
-                return defaultLang;
-            }
-
-            if (cookieValue.Contains("UL=1033"))
-            {
-                return "en";
-            }
-
-            if (cookieValue.Contains("UL=1044"))
-            {
-                return "nb";
-            }
-
-            if (cookieValue.Contains("UL=2068"))
-            {
-                return "nn";
-            }
-            
-            return defaultLang;
         }
     }
 }

--- a/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
+++ b/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
@@ -90,7 +90,9 @@ namespace Altinn.Platform.Receipt
 
                 if (!string.IsNullOrEmpty(profile?.ProfileSettingPreference?.Language))
                 {
-                    profile.ProfileSettingPreference.Language = GetLanguageFromAltinnPersistenceCookie(profile.ProfileSettingPreference.Language);
+                    profile.ProfileSettingPreference.Language = GetLanguageFromAltinnPersistenceCookie(
+                        _httpContextAccessor.HttpContext.Request.Cookies["altinnPersistentContext"],
+                        profile.ProfileSettingPreference.Language);
                 }
 
                 return Ok(profile);
@@ -158,13 +160,17 @@ namespace Altinn.Platform.Receipt
             }
         }
 
-        private string GetLanguageFromAltinnPersistenceCookie(string dafaultLang = "nb")
+        /// <summary>
+        /// Gets the language from the Altinn persistence cookie.
+        /// </summary>
+        /// <param name="cookieValue">The value of the Altinn persistence cookie containing language information.</param>
+        /// <param name="defaultLang">The default language to return if the cookie is not found or doesn't contain language information.</param>
+        /// <returns>The language code ('en', 'nb', 'nn') extracted from the Altinn persistence cookie, or the default language if not found.</returns>
+        internal string GetLanguageFromAltinnPersistenceCookie(string cookieValue, string defaultLang = "nb")
         {
-            string cookieValue = _httpContextAccessor.HttpContext.Request.Cookies["altinnPersistentContext"];
-
             if (cookieValue == null)
             {
-                return dafaultLang;
+                return defaultLang;
             }
 
             if (cookieValue.Contains("UL=1033"))
@@ -182,7 +188,7 @@ namespace Altinn.Platform.Receipt
                 return "nn";
             }
             
-            return dafaultLang;
+            return defaultLang;
         }
     }
 }

--- a/src/backend/Altinn.Receipt/Helpers/LanguageHelper.cs
+++ b/src/backend/Altinn.Receipt/Helpers/LanguageHelper.cs
@@ -13,7 +13,7 @@ public static class LanguageHelper
     /// <returns>The language code ('en', 'nb', 'nn') extracted from the Altinn persistence cookie, or the default language if not found.</returns>
     public static string GetLanguageFromAltinnPersistenceCookie(string cookieValue, string defaultLang = "nb")
     {
-        if (cookieValue == null)
+        if (string.IsNullOrEmpty(cookieValue))
         {
             return defaultLang;
         }

--- a/src/backend/Altinn.Receipt/Helpers/LanguageHelper.cs
+++ b/src/backend/Altinn.Receipt/Helpers/LanguageHelper.cs
@@ -9,13 +9,12 @@ public static class LanguageHelper
     /// Gets the language from the Altinn persistence cookie.
     /// </summary>
     /// <param name="cookieValue">The value of the Altinn persistence cookie containing language information.</param>
-    /// <param name="defaultLang">The default language to return if the cookie is not found or doesn't contain language information.</param>
-    /// <returns>The language code ('en', 'nb', 'nn') extracted from the Altinn persistence cookie, or the default language if not found.</returns>
-    public static string GetLanguageFromAltinnPersistenceCookie(string cookieValue, string defaultLang = "nb")
+    /// <returns>The language code ('en', 'nb', 'nn') extracted from the Altinn persistence cookie, or empty string if language not found.</returns>
+    public static string GetLanguageFromAltinnPersistenceCookie(string cookieValue)
     {
         if (string.IsNullOrEmpty(cookieValue))
         {
-            return defaultLang;
+            return string.Empty;
         }
 
         if (cookieValue.Contains("UL=1033"))
@@ -33,6 +32,6 @@ public static class LanguageHelper
             return "nn";
         }
         
-        return defaultLang;
+        return string.Empty;
     }
 }

--- a/src/backend/Altinn.Receipt/Helpers/LanguageHelper.cs
+++ b/src/backend/Altinn.Receipt/Helpers/LanguageHelper.cs
@@ -1,0 +1,38 @@
+namespace Altinn.Platform.Receipt.Helpers;
+
+/// <summary>
+/// Provides helper methods for language-related operations.
+/// </summary>
+public static class LanguageHelper
+{
+    /// <summary>
+    /// Gets the language from the Altinn persistence cookie.
+    /// </summary>
+    /// <param name="cookieValue">The value of the Altinn persistence cookie containing language information.</param>
+    /// <param name="defaultLang">The default language to return if the cookie is not found or doesn't contain language information.</param>
+    /// <returns>The language code ('en', 'nb', 'nn') extracted from the Altinn persistence cookie, or the default language if not found.</returns>
+    public static string GetLanguageFromAltinnPersistenceCookie(string cookieValue, string defaultLang = "nb")
+    {
+        if (cookieValue == null)
+        {
+            return defaultLang;
+        }
+
+        if (cookieValue.Contains("UL=1033"))
+        {
+            return "en";
+        }
+
+        if (cookieValue.Contains("UL=1044"))
+        {
+            return "nb";
+        }
+
+        if (cookieValue.Contains("UL=2068"))
+        {
+            return "nn";
+        }
+        
+        return defaultLang;
+    }
+}

--- a/src/frontend/src/features/receipt/hooks.ts
+++ b/src/frontend/src/features/receipt/hooks.ts
@@ -8,6 +8,7 @@ import type {
   IInstance,
   IParty,
   IProfile,
+  IUserCookieLanguage,
   IExtendedInstance,
   ITextResource,
   IAltinnOrgs,
@@ -17,6 +18,7 @@ import {
   altinnOrganisationsUrl,
   getApplicationMetadataUrl,
   getUserUrl,
+  getUserLanguageUrl,
   getExtendedInstanceUrl,
   getTextResourceUrl,
 } from 'src/utils/receiptUrlHelper';
@@ -128,6 +130,7 @@ export const useFetchInitialData = () => {
     const instanceAbortController = new AbortController();
     const orgAbortController = new AbortController();
     const userAbortController = new AbortController();
+    const languageAbortController = new AbortController();
     const appAbortController = new AbortController();
     const textAbortController = new AbortController();
 
@@ -173,7 +176,7 @@ export const useFetchInitialData = () => {
 
     const fetchInitialData = async () => {
       try {
-        const [instanceResponse, orgResponse, userResponse] = await Promise.all(
+        const [instanceResponse, orgResponse, userResponse, userLanguage] = await Promise.all(
           [
             Axios.get<IExtendedInstance>(getExtendedInstanceUrl(), {
               signal: instanceAbortController.signal,
@@ -184,8 +187,15 @@ export const useFetchInitialData = () => {
             Axios.get<IProfile>(getUserUrl(), {
               signal: userAbortController.signal,
             }),
+            Axios.get<IUserCookieLanguage>(getUserLanguageUrl(), {
+              signal: languageAbortController.signal,
+            }),
           ],
         );
+
+        if (userLanguage.status === 200 && userLanguage.data.language != "") {
+          userResponse.data.profileSettingPreference.language = userLanguage.data.language
+        }
 
         const langs = Object.keys(languageLookup).filter(
           element => element !== userResponse.data.profileSettingPreference.language

--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -204,6 +204,10 @@ export interface IProfileSettingPreference {
   doNotPromptForParty: boolean;
 }
 
+export interface IUserCookieLanguage {
+  language: string;
+}
+
 export interface ISelfLinks {
   apps: string;
   platform: string;

--- a/src/frontend/src/utils/receiptUrlHelper.ts
+++ b/src/frontend/src/utils/receiptUrlHelper.ts
@@ -31,6 +31,10 @@ export function getUserUrl() {
   return `${window.location.origin}/receipt/api/v1/users/current`;
 }
 
+export function getUserLanguageUrl() {
+  return `${window.location.origin}/receipt/api/v1/users/current/language`;
+}
+
 export function getTextResourceUrl(org: string, app: string, language: string) {
   return `${window.location.origin}/storage/api/v1/applications/${org}/${app}/texts/${language}`;
 }

--- a/test/LanguageHelperTests.cs
+++ b/test/LanguageHelperTests.cs
@@ -5,11 +5,11 @@ namespace Altinn.Platform.Receipt.Helpers.Tests
     public class LanguageHelperTests
     {
         [Fact]
-        public void GetLanguageFromAltinnPersistenceCookie_NullCookie_ReturnsDefaultLanguage()
+        public void GetLanguageFromAltinnPersistenceCookie_NullCookie_ReturnsEmptyString()
         {
             // Arrange
             string cookieValue = null;
-            string expectedLanguage = "nb"; // Default language is 'nb'
+            string expectedLanguage = string.Empty; // Default is empty string
 
             // Act
             string result = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(cookieValue);
@@ -61,11 +61,11 @@ namespace Altinn.Platform.Receipt.Helpers.Tests
         }
 
         [Fact]
-        public void GetLanguageFromAltinnPersistenceCookie_UnsupportedLanguage_ReturnsDefaultLanguage()
+        public void GetLanguageFromAltinnPersistenceCookie_UnsupportedLanguage_ReturnsEmptyString()
         {
             // Arrange
             string cookieValue = "UL=9999"; // Cookie containing unsupported language
-            string expectedLanguage = "nb"; // Default language is 'nb'
+            string expectedLanguage = string.Empty; // Default is empty string
 
             // Act
             string result = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(cookieValue);

--- a/test/LanguageHelperTests.cs
+++ b/test/LanguageHelperTests.cs
@@ -1,0 +1,77 @@
+using Xunit;
+
+namespace Altinn.Platform.Receipt.Helpers.Tests
+{
+    public class LanguageHelperTests
+    {
+        [Fact]
+        public void GetLanguageFromAltinnPersistenceCookie_NullCookie_ReturnsDefaultLanguage()
+        {
+            // Arrange
+            string cookieValue = null;
+            string expectedLanguage = "nb"; // Default language is 'nb'
+
+            // Act
+            string result = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(cookieValue);
+
+            // Assert
+            Assert.Equal(expectedLanguage, result);
+        }
+
+        [Fact]
+        public void GetLanguageFromAltinnPersistenceCookie_ContainsEnglishLanguage_ReturnsEnglish()
+        {
+            // Arrange
+            string cookieValue = "UL=1033"; // Cookie containing English language
+            string expectedLanguage = "en";
+
+            // Act
+            string result = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(cookieValue);
+
+            // Assert
+            Assert.Equal(expectedLanguage, result);
+        }
+
+        [Fact]
+        public void GetLanguageFromAltinnPersistenceCookie_ContainsNorwegianLanguage_ReturnsNorwegian()
+        {
+            // Arrange
+            string cookieValue = "UL=1044"; // Cookie containing Norwegian language
+            string expectedLanguage = "nb";
+
+            // Act
+            string result = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(cookieValue);
+
+            // Assert
+            Assert.Equal(expectedLanguage, result);
+        }
+
+        [Fact]
+        public void GetLanguageFromAltinnPersistenceCookie_ContainsNynorskLanguage_ReturnsNynorsk()
+        {
+            // Arrange
+            string cookieValue = "UL=2068"; // Cookie containing Nynorsk language
+            string expectedLanguage = "nn";
+
+            // Act
+            string result = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(cookieValue);
+
+            // Assert
+            Assert.Equal(expectedLanguage, result);
+        }
+
+        [Fact]
+        public void GetLanguageFromAltinnPersistenceCookie_UnsupportedLanguage_ReturnsDefaultLanguage()
+        {
+            // Arrange
+            string cookieValue = "UL=9999"; // Cookie containing unsupported language
+            string expectedLanguage = "nb"; // Default language is 'nb'
+
+            // Act
+            string result = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(cookieValue);
+
+            // Assert
+            Assert.Equal(expectedLanguage, result);
+        }
+    }
+}

--- a/test/ReceiptControllerTests.cs
+++ b/test/ReceiptControllerTests.cs
@@ -15,6 +15,7 @@ using Altinn.Platform.Receipt.Tests.Testdata;
 using AltinnCore.Authentication.Constants;
 using AltinnCore.Authentication.JwtCookie;
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
@@ -35,6 +36,7 @@ namespace Altinn.Platform.Receipt.Tests
         private readonly Mock<IRegister> _registerMock;
         private readonly Mock<IStorage> _storageMock;
         private readonly Mock<IProfile> _profileMock;
+        private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock;
 
         /// <summary>
         /// Initialises a new instance of the <see cref="ReceiptControllerTests"/> class with the given WebApplicationFactory.
@@ -46,6 +48,7 @@ namespace Altinn.Platform.Receipt.Tests
             _registerMock = new Mock<IRegister>();
             _storageMock = new Mock<IStorage>();
             _profileMock = new Mock<IProfile>();
+            _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
         }
 
         [Fact]
@@ -93,6 +96,23 @@ namespace Altinn.Platform.Receipt.Tests
 
             HttpResponseMessage response = await client.GetAsync(url);
             Assert.Equal(System.Net.HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
+        public async void GetCurrentUserLanguage_TC01_NoCookie_ReturnsNoContent()
+        {
+            _profileMock
+           .Setup(p => p.GetUser(It.IsAny<int>()))
+           .ReturnsAsync(UserProfiles.User1);
+
+            HttpClient client = GetTestClient(_registerMock, _storageMock, _profileMock);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetUserToken(3));
+            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            string url = $"{BasePath}users/current/language";
+
+            HttpResponseMessage response = await client.GetAsync(url);
+
+            Assert.Equal(System.Net.HttpStatusCode.NoContent, response.StatusCode);
         }
 
         [Fact]


### PR DESCRIPTION
Receipt should choose language from `altinnPersistentContext` cookie

## Description
Receipt should choose language from `altinnPersistentContext` cookie which is wasn't doing.

## Related Issue(s)
- #259 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
