### PR TITLE
Use workload identity in backend

### DIFF
--- a/src/backend/Altinn.Receipt/Configuration/KeyVaultSettings.cs
+++ b/src/backend/Altinn.Receipt/Configuration/KeyVaultSettings.cs
@@ -1,25 +1,10 @@
 ﻿namespace Altinn.Platform.Receipt.Configuration;
 
 /// <summary>
-/// The key vault settings used to fetch certificate information from key vault
+/// The key vault settings used to fetch values from key vault
 /// </summary>
 public class KeyVaultSettings
 {
-    /// <summary>
-    /// The key vault reader client id
-    /// </summary>
-    public string ClientId { get; set; } = string.Empty;
-
-    /// <summary>
-    /// The key vault client secret
-    /// </summary>
-    public string ClientSecret { get; set; } = string.Empty;
-
-    /// <summary>
-    /// The key vault tenant Id
-    /// </summary>
-    public string TenantId { get; set; } = string.Empty;
-
     /// <summary>
     /// The uri to the key vault
     /// </summary>

--- a/src/backend/Altinn.Receipt/Program.cs
+++ b/src/backend/Altinn.Receipt/Program.cs
@@ -90,20 +90,15 @@ async Task ConnectToKeyVaultAndSetApplicationInsights(ConfigurationManager confi
 {
     KeyVaultSettings keyVaultSettings = new();
     config.GetSection("kvSetting").Bind(keyVaultSettings);
-    if (!string.IsNullOrEmpty(keyVaultSettings.ClientId) &&
-        !string.IsNullOrEmpty(keyVaultSettings.TenantId) &&
-        !string.IsNullOrEmpty(keyVaultSettings.ClientSecret) &&
-        !string.IsNullOrEmpty(keyVaultSettings.SecretUri))
+    if (!string.IsNullOrEmpty(keyVaultSettings.SecretUri))
     {
-        logger.LogInformation("Program // Configure key vault client // App");
-        Environment.SetEnvironmentVariable("AZURE_CLIENT_ID", keyVaultSettings.ClientId);
-        Environment.SetEnvironmentVariable("AZURE_CLIENT_SECRET", keyVaultSettings.ClientSecret);
-        Environment.SetEnvironmentVariable("AZURE_TENANT_ID", keyVaultSettings.TenantId);
+        logger.LogInformation("Program // Set app insights connection string // App");
+
         var azureCredentials = new DefaultAzureCredential();
 
-        config.AddAzureKeyVault(new Uri(keyVaultSettings.SecretUri), azureCredentials);
+        var client = new SecretClient(new Uri(keyVaultSettings.SecretUri), azureCredentials);
 
-        SecretClient client = new SecretClient(new Uri(keyVaultSettings.SecretUri), azureCredentials);
+        config.AddAzureKeyVault(new Uri(keyVaultSettings.SecretUri), azureCredentials);
 
         try
         {


### PR DESCRIPTION
Use workload identity

## Description
Receipt should use workload identity to access Azure resources. In this case, azure key vault.

## Related Issue(s)
- #264

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
