### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/test/Altinn.Platform.Receipt.Tests.csproj
+++ b/test/Altinn.Platform.Receipt.Tests.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.1" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Description
Now that Receipt use an updated version of AccessTokenClient, the test project have access to an updated version of IdentityModel.

## Related Issue(s)
- Patching Thursday