### PR TITLE
Hotfix: Downgrade dompurify to fix breaking build

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -16,7 +16,7 @@
     "@material-ui/core": "4.12.4",
     "axios": "1.7.7",
     "classnames": "2.5.1",
-    "dompurify": "3.2.0",
+    "dompurify": "3.1.7",
     "html-react-parser": "5.1.18",
     "marked": "14.1.4",
     "moment": "2.30.1",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -5128,10 +5128,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.2.0":
-  version: 3.2.0
-  resolution: "dompurify@npm:3.2.0"
-  checksum: 54bd8e113474c1444dbabae5ea404e0d4a1bf042004070bcda2de3ea6c209f8c40686aebf60caff144bdae84175784504a42d7ac7f484fd6932d7bc4a53bf378
+"dompurify@npm:3.1.7":
+  version: 3.1.7
+  resolution: "dompurify@npm:3.1.7"
+  checksum: 0a9b811bbc94f3dba60cf6486962362b0f1a5b4ab789f5e1cbd4749b6ba1a1fad190a677a962dc8850ce28764424765fe425e9d6508e4e93ba648ef15d54bc24
   languageName: node
   linkType: hard
 
@@ -10540,7 +10540,7 @@ __metadata:
     classnames: 2.5.1
     cross-env: 7.0.3
     css-loader: 7.1.2
-    dompurify: 3.2.0
+    dompurify: 3.1.7
     eslint: 9.15.0
     eslint-config-prettier: 9.1.0
     eslint-import-resolver-typescript: 3.6.3


### PR DESCRIPTION
## Description
The dotnet container [can no longer build properly](https://github.com/Altinn/altinn-receipt/actions/runs/11956874773/job/33332659986), after [patching dompurify 3.1.7 -> 3.2.0](https://github.com/Altinn/altinn-receipt/pull/408)

~~## Related Issue(s)~~ N/A (issue located in private repo)


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
