### PR TITLE
fix(deps): Revert breaking major change of react v18 -> 19

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -20,9 +20,9 @@
     "html-react-parser": "5.2.1",
     "marked": "15.0.4",
     "moment": "2.30.1",
-    "react": "19.0.0",
+    "react": "18.3.1",
     "react-content-loader": "7.0.2",
-    "react-dom": "19.0.0"
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
     "@babel/core": "7.26.0",
@@ -61,8 +61,8 @@
     "mini-css-extract-plugin": "2.9.2",
     "msw": "2.6.9",
     "prettier": "3.4.2",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "rimraf": "6.0.1",
     "source-map-loader": "5.0.0",
     "terser-webpack-plugin": "5.3.11",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -8834,7 +8834,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -10404,14 +10404,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:19.0.0":
-  version: 19.0.0
-  resolution: "react-dom@npm:19.0.0"
+"react-dom@npm:18.3.1":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
   dependencies:
-    scheduler: ^0.25.0
+    loose-envify: ^1.1.0
+    scheduler: ^0.23.2
   peerDependencies:
-    react: ^19.0.0
-  checksum: 009cc6e575263a0d1906f9dd4aa6532d2d3d0d71e4c2b7777c8fe4de585fa06b5b77cdc2e0fbaa2f3a4a5e5d3305c189ba152153f358ee7da4d9d9ba5d3a8975
+    react: ^18.3.1
+  checksum: 298954ecd8f78288dcaece05e88b570014d8f6dce5db6f66e6ee91448debeb59dcd31561dddb354eee47e6c1bb234669459060deb238ed0213497146e555a0b9
   languageName: node
   linkType: hard
 
@@ -10458,10 +10459,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:19.0.0":
-  version: 19.0.0
-  resolution: "react@npm:19.0.0"
-  checksum: 86de15d85b2465feb40297a90319c325cb07cf27191a361d47bcfe8c6126c973d660125aa67b8f4cbbe39f15a2f32efd0c814e98196d8e5b68c567ba40a399c6
+"react@npm:18.3.1":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: a27bcfa8ff7c15a1e50244ad0d0c1cb2ad4375eeffefd266a64889beea6f6b64c4966c9b37d14ee32d6c9fcd5aa6ba183b6988167ab4d127d13e7cb5b386a376
   languageName: node
   linkType: hard
 
@@ -10566,9 +10569,9 @@ __metadata:
     moment: 2.30.1
     msw: 2.6.9
     prettier: 3.4.2
-    react: 19.0.0
+    react: 18.3.1
     react-content-loader: 7.0.2
-    react-dom: 19.0.0
+    react-dom: 18.3.1
     rimraf: 6.0.1
     source-map-loader: 5.0.0
     terser-webpack-plugin: 5.3.11
@@ -10999,10 +11002,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "scheduler@npm:0.25.0"
-  checksum: b7bb9fddbf743e521e9aaa5198a03ae823f5e104ebee0cb9ec625392bb7da0baa1c28ab29cee4b1e407a94e76acc6eee91eeb749614f91f853efda2613531566
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: 3e82d1f419e240ef6219d794ff29c7ee415fbdc19e038f680a10c067108e06284f1847450a210b29bbaf97b9d8a97ced5f624c31c681248ac84c80d56ad5a2c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
The latest major upgrade of react and react-dom breaks the component, and must be reverted.

## Related Issue(s)
Weekly patching

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] ~Manual testing done (required)~
- [ ] ~Relevant automated test added (if you find this hard, leave it and we'll help out)~
- [x] All tests run green

## Documentation
- [ ] ~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~
