### PR TITLE
Added support to hide attachment groups

### DIFF
--- a/src/backend/Altinn.Receipt/Configuration/GeneralSettings.cs
+++ b/src/backend/Altinn.Receipt/Configuration/GeneralSettings.cs
@@ -19,4 +19,9 @@ public class GeneralSettings
     /// Name of the cookie for runtime
     /// </summary>
     public string RuntimeCookieName { get; set; }
+
+    /// <summary>
+    /// The attachment groups to hide
+    /// </summary>
+    public string AttachmentGroupsToHide { get; set; }
 }

--- a/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
+++ b/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
@@ -70,7 +70,6 @@ namespace Altinn.Platform.Receipt
         public IActionResult Index(int instanceOwnerId, Guid instanceId)
         {
             _logger.LogInformation("Getting receipt for: {instanceOwnerId} for instance with id: {instanceId}", instanceOwnerId, instanceId);
-            Response.Cookies.Append("AltinnStudioRuntime", TokenHelper.GetUserToken());
             return View("receipt");
         }
 

--- a/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
+++ b/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
@@ -167,26 +167,12 @@ namespace Altinn.Platform.Receipt
         /// <summary>
         /// Gets the attachment groups to hide
         /// </summary>
-        /// <returns>The attachment groups or 404(if not found)</returns>
+        /// <returns>The attachment groups</returns>
         [HttpGet]
         [Route("receipt/api/v1/application/attachmentgroupstohide")]
         public ActionResult GetAttachmentGroupsToHide()
         {
-            string attachmentgroupstohide = _generalSettings.Value.AttachmentGroupsToHide;
-
-            try
-            {
-                if (string.IsNullOrEmpty(attachmentgroupstohide))
-                {
-                    return NoContent();
-                }
-
-                return Ok(new { attachmentgroupstohide });
-            }
-            catch (PlatformHttpException e)
-            {
-                return HandlePlatformHttpException(e);
-            }
+            return Ok(new { _generalSettings.Value.AttachmentGroupsToHide });
         }
 
         private ActionResult HandlePlatformHttpException(PlatformHttpException e)

--- a/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
+++ b/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Profile.Models;
+using Altinn.Platform.Receipt.Configuration;
 using Altinn.Platform.Receipt.Helpers;
 using Altinn.Platform.Receipt.Model;
 using Altinn.Platform.Receipt.Services.Interfaces;
@@ -15,6 +16,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Altinn.Platform.Receipt
 {
@@ -30,6 +32,7 @@ namespace Altinn.Platform.Receipt
         private readonly IProfile _profile;
         private readonly ILogger _logger;
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IOptions<GeneralSettings> _generalSettings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReceiptController"/> class
@@ -39,18 +42,21 @@ namespace Altinn.Platform.Receipt
         /// <param name="profile">the profile service</param>
         /// <param name="logger">the logger</param>
         /// <param name="httpContextAccessor">the HTTP context accessor</param>
+        /// <param name="generalSettings">The application general settings</param>
         public ReceiptController(
             IRegister register,
             IStorage storage,
             IProfile profile,
             ILogger<ReceiptController> logger,
-            IHttpContextAccessor httpContextAccessor)
+            IHttpContextAccessor httpContextAccessor,
+            IOptions<GeneralSettings> generalSettings)
         {
             _register = register;
             _storage = storage;
             _profile = profile;
             _logger = logger;
             _httpContextAccessor = httpContextAccessor;
+            _generalSettings = generalSettings;
         }
 
         /// <summary>
@@ -64,6 +70,7 @@ namespace Altinn.Platform.Receipt
         public IActionResult Index(int instanceOwnerId, Guid instanceId)
         {
             _logger.LogInformation("Getting receipt for: {instanceOwnerId} for instance with id: {instanceId}", instanceOwnerId, instanceId);
+            Response.Cookies.Append("AltinnStudioRuntime", TokenHelper.GetUserToken());
             return View("receipt");
         }
 
@@ -156,6 +163,31 @@ namespace Altinn.Platform.Receipt
             }
 
             return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets the attachment groups to hide
+        /// </summary>
+        /// <returns>The attachment groups or 404(if not found)</returns>
+        [HttpGet]
+        [Route("receipt/api/v1/application/attachmentgroupstohide")]
+        public ActionResult GetAttachmentGroupsToHide()
+        {
+            string attachmentgroupstohide = _generalSettings.Value.AttachmentGroupsToHide;
+
+            try
+            {
+                if (string.IsNullOrEmpty(attachmentgroupstohide))
+                {
+                    return NoContent();
+                }
+
+                return Ok(new { attachmentgroupstohide });
+            }
+            catch (PlatformHttpException e)
+            {
+                return HandlePlatformHttpException(e);
+            }
         }
 
         private ActionResult HandlePlatformHttpException(PlatformHttpException e)

--- a/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
+++ b/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
@@ -172,7 +172,8 @@ namespace Altinn.Platform.Receipt
         [Route("receipt/api/v1/application/attachmentgroupstohide")]
         public ActionResult GetAttachmentGroupsToHide()
         {
-            return Ok(new { _generalSettings.Value.AttachmentGroupsToHide });
+            string attachmentgroupstohide = _generalSettings.Value.AttachmentGroupsToHide;
+            return Ok(new { attachmentgroupstohide });
         }
 
         private ActionResult HandlePlatformHttpException(PlatformHttpException e)

--- a/src/backend/Altinn.Receipt/Program.cs
+++ b/src/backend/Altinn.Receipt/Program.cs
@@ -152,6 +152,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddControllersWithViews();
     services.AddHealthChecks().AddCheck<HealthCheck>("receipt_health_check");
     GeneralSettings generalSettings = config.GetSection("GeneralSettings").Get<GeneralSettings>();
+    services.Configure<GeneralSettings>(config.GetSection("GeneralSettings"));
 
     services.AddAuthentication(JwtCookieDefaults.AuthenticationScheme)
         .AddJwtCookie(JwtCookieDefaults.AuthenticationScheme, options =>

--- a/src/backend/Altinn.Receipt/appsettings.json
+++ b/src/backend/Altinn.Receipt/appsettings.json
@@ -2,7 +2,8 @@
   "GeneralSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
     "Hostname": "at22.altinn.cloud",
-    "RuntimeCookieName": "AltinnStudioRuntime"
+    "RuntimeCookieName": "AltinnStudioRuntime",
+    "AttachmentGroupsToHide": "group.formdatahtml;group.formdatasource;group.signaturesource;group.paymentsource;group.activities"
   },
   "PlatformSettings": {
     "ApiProfileEndpoint": "http://localhost:5101/profile/api/v1/",

--- a/src/frontend/src/features/receipt/hooks.ts
+++ b/src/frontend/src/features/receipt/hooks.ts
@@ -233,7 +233,10 @@ export const useFetchInitialData = () => {
             fetchTextResources(instanceResponse.data.instance.org, app, langs),
           ]);
 
-          applicationResponse.data.attachmentGroupsToHide = attachmentGroupsToHide.data.attachmentgroupstohide.split(';');
+          if (attachmentGroupsToHide.data.attachmentgroupstohide != null)
+          {
+            applicationResponse.data.attachmentGroupsToHide = attachmentGroupsToHide.data.attachmentgroupstohide.split(';');
+          }
 
         setApplication(applicationResponse.data);
         setTextResources(appTextResourcesResponse.response.data.resources);

--- a/src/frontend/src/features/receipt/hooks.ts
+++ b/src/frontend/src/features/receipt/hooks.ts
@@ -12,6 +12,7 @@ import type {
   IExtendedInstance,
   ITextResource,
   IAltinnOrgs,
+  IAttachmentGroupsToHide,
 } from 'src/types';
 
 import {
@@ -21,6 +22,7 @@ import {
   getUserLanguageUrl,
   getExtendedInstanceUrl,
   getTextResourceUrl,
+  getAttachmentGroupingsToHide,
 } from 'src/utils/receiptUrlHelper';
 import { buildInstanceContext } from 'src/utils/instanceContext';
 import { languageLookup, getLanguageFromCode } from 'src/language';
@@ -132,6 +134,7 @@ export const useFetchInitialData = () => {
     const languageAbortController = new AbortController();
     const appAbortController = new AbortController();
     const textAbortController = new AbortController();
+    const attachmentgroupsToHideAbortController = new AbortController();
 
     const fetchTextResources = (
       org: string,
@@ -175,7 +178,7 @@ export const useFetchInitialData = () => {
 
     const fetchInitialData = async () => {
       try {
-        const [instanceResponse, orgResponse, userResponse, userLanguage] = await Promise.all(
+        const [instanceResponse, orgResponse, userResponse, userLanguage, attachmentGroupsToHide] = await Promise.all(
           [
             Axios.get<IExtendedInstance>(getExtendedInstanceUrl(), {
               signal: instanceAbortController.signal,
@@ -189,11 +192,14 @@ export const useFetchInitialData = () => {
             Axios.get<IUserCookieLanguage>(getUserLanguageUrl(), {
               signal: languageAbortController.signal,
             }),
+            Axios.get<IAttachmentGroupsToHide>(getAttachmentGroupingsToHide(), {
+              signal: attachmentgroupsToHideAbortController.signal,
+            }),
           ],
         );
 
         if (userLanguage.status === 200 && userLanguage.data.language != "") {
-          userResponse.data.profileSettingPreference.language = userLanguage.data.language
+          userResponse.data.profileSettingPreference.language = userLanguage.data.language;
         }
 
         const langs = Object.keys(languageLookup).filter(
@@ -226,6 +232,8 @@ export const useFetchInitialData = () => {
             ),
             fetchTextResources(instanceResponse.data.instance.org, app, langs),
           ]);
+
+          applicationResponse.data.attachmentGroupsToHide = attachmentGroupsToHide.data.attachmentgroupstohide.split(';');
 
         setApplication(applicationResponse.data);
         setTextResources(appTextResourcesResponse.response.data.resources);

--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -14,6 +14,7 @@ export interface IApplication {
   partyTypesAllowed: IPartyTypesAllowed;
   title: ITitle;
   onEntry?: IOnEntry;
+  attachmentGroupsToHide?: string[];
 }
 
 
@@ -208,6 +209,10 @@ export interface IProfileSettingPreference {
 
 export interface IUserCookieLanguage {
   language: string;
+}
+
+export interface IAttachmentGroupsToHide {
+  attachmentgroupstohide: string;
 }
 
 export interface ISelfLinks {

--- a/src/frontend/src/utils/attachmentsUtils.ts
+++ b/src/frontend/src/utils/attachmentsUtils.ts
@@ -67,11 +67,13 @@ export const getAttachmentGroupings = (
 
   attachments.forEach((attachment: IAttachment) => {
     const grouping = getGroupingForAttachment(attachment, applicationMetadata);
-    const title = getTextResourceByKey(grouping, textResources);
-    if (!attachmentGroupings[title]) {
-      attachmentGroupings[title] = [];
+    if (grouping == null || applicationMetadata.attachmentGroupsToHide == null || !applicationMetadata.attachmentGroupsToHide.includes(grouping)){
+      const title = getTextResourceByKey(grouping, textResources);
+      if (!attachmentGroupings[title]) {
+        attachmentGroupings[title] = [];
+      }
+      attachmentGroupings[title].push(attachment);
     }
-    attachmentGroupings[title].push(attachment);
   });
 
   return attachmentGroupings;

--- a/src/frontend/src/utils/receiptUrlHelper.ts
+++ b/src/frontend/src/utils/receiptUrlHelper.ts
@@ -45,3 +45,8 @@ export function getAltinnUrl() {
   }
   return `${window.location.origin}/`;
 }
+
+export function getAttachmentGroupingsToHide() {
+  return `${window.location.origin}/receipt/api/v1/application/attachmentgroupstohide`;
+}
+

--- a/test/ReceiptControllerTests.cs
+++ b/test/ReceiptControllerTests.cs
@@ -259,9 +259,10 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
 
         HttpResponseMessage response = await client.GetAsync(url);
         string actual = await response.Content.ReadAsStringAsync();
+        string expected = "{\"attachmentGroupsToHide\":\"group.formdatahtml;group.formdatasource;group.signaturesource;group.paymentsource;group.activities\"}";
 
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
-        Assert.IsType<string>(actual);
+        Assert.Equal(expected, actual);
     }
 
     private static string GetUserToken(int userId)

--- a/test/ReceiptControllerTests.cs
+++ b/test/ReceiptControllerTests.cs
@@ -259,7 +259,7 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
 
         HttpResponseMessage response = await client.GetAsync(url);
         string actual = await response.Content.ReadAsStringAsync();
-        string expected = "{\"attachmentGroupsToHide\":\"group.formdatahtml;group.formdatasource;group.signaturesource;group.paymentsource;group.activities\"}";
+        string expected = "{\"attachmentgroupstohide\":\"group.formdatahtml;group.formdatasource;group.signaturesource;group.paymentsource;group.activities\"}";
 
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(expected, actual);

--- a/test/ReceiptControllerTests.cs
+++ b/test/ReceiptControllerTests.cs
@@ -247,6 +247,23 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
     }
 
+    [Fact]
+    public async Task GetAttachmentGroupsToHide_TC01_ReturnsContent()
+    {
+        _profileMock.Setup(p => p.GetUser(It.IsAny<int>())).ReturnsAsync(UserProfiles.User1);
+
+        HttpClient client = GetTestClient(_registerMock, _storageMock, _profileMock);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetUserToken(3));
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        string url = $"{BasePath}application/attachmentgroupstohide";
+
+        HttpResponseMessage response = await client.GetAsync(url);
+        string actual = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+        Assert.IsType<string>(actual);
+    }
+
     private static string GetUserToken(int userId)
     {
         List<Claim> claims = new List<Claim>();

--- a/test/appsettings.json
+++ b/test/appsettings.json
@@ -2,7 +2,8 @@
   "GeneralSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5040/authentication/api/v1/openid/",
     "Hostname": "at22.altinn.cloud",
-    "RuntimeCookieName": "AltinnStudioRuntime"
+    "RuntimeCookieName": "AltinnStudioRuntime",
+    "AttachmentGroupsToHide": "group.formdatahtml;group.formdatasource;group.signaturesource;group.paymentsource;group.activities"
   },
   "PlatformSettings": {
     "ApiProfileEndpoint": "https://platform.tt02.altinn.no/profile/api/v1/",


### PR DESCRIPTION
Added support to hide attachment groups

## Description
Added support to hide attachment groups
This will most likely only be relevant for A2 migrated apps.
These apps needs to be able to hide some of the attachments connected to the instance.