### PR TITLE
Bump undici in package.json and run yarn install

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -69,7 +69,7 @@
     "ts-jest": "29.2.5",
     "ts-loader": "9.5.1",
     "typescript": "4.9.5",
-    "undici": "^7.0.0",
+    "undici": "^7.2.3",
     "webpack": "5.97.1",
     "webpack-cli": "6.0.1",
     "webpack-dev-server": "5.2.0"

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -69,7 +69,7 @@
     "ts-jest": "29.2.5",
     "ts-loader": "9.5.1",
     "typescript": "4.9.5",
-    "undici": "^7.2.3",
+    "undici": "^7.3.0",
     "webpack": "5.97.1",
     "webpack-cli": "6.0.1",
     "webpack-dev-server": "5.2.0"

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -11049,7 +11049,7 @@ __metadata:
     ts-jest: 29.2.5
     ts-loader: 9.5.1
     typescript: 4.9.5
-    undici: ^7.2.3
+    undici: ^7.3.0
     webpack: 5.97.1
     webpack-cli: 6.0.1
     webpack-dev-server: 5.2.0
@@ -12926,7 +12926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.2.3":
+"undici@npm:^7.3.0":
   version: 7.3.0
   resolution: "undici@npm:7.3.0"
   checksum: 5cf37a51d1449370c7c936fdfefb6be907a59af2829520475a837e81fe709771cf678428fe6beb4c80b168da0570496d13b2ecbf6f52211f844b2a360c6fc6e0

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -11049,7 +11049,7 @@ __metadata:
     ts-jest: 29.2.5
     ts-loader: 9.5.1
     typescript: 4.9.5
-    undici: ^7.0.0
+    undici: ^7.2.3
     webpack: 5.97.1
     webpack-cli: 6.0.1
     webpack-dev-server: 5.2.0
@@ -12926,10 +12926,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.0.0":
-  version: 7.2.3
-  resolution: "undici@npm:7.2.3"
-  checksum: 93bfe6b1f5acc1c7180a2d6a04b22bda8223ee4c683a7f240b261b272eeb3bd46e9514f70afe8ad3e55e82ca06ade19cd7bc590202a0b4118803a75daf776b5d
+"undici@npm:^7.2.3":
+  version: 7.3.0
+  resolution: "undici@npm:7.3.0"
+  checksum: 5cf37a51d1449370c7c936fdfefb6be907a59af2829520475a837e81fe709771cf678428fe6beb4c80b168da0570496d13b2ecbf6f52211f844b2a360c6fc6e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Renovate didn't bump the version in package.json, in PR #449 .
There seems to be an even newer version available, [v7.3.0](https://github.com/nodejs/undici/releases/tag/v7.3.0). While it was published only yesterday, it doesn't list any breaking changes, so we can might as well upgrade to this one right away

## Related Issue(s)
- N/A / standard patching routine

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] ~Relevant automated test added (if you find this hard, leave it and we'll help out)~
- [ ] All tests run green

## Documentation
- [ ] ~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~
