### PR TITLE
refactor: use Altinn 3 endpoints for change and redirect

### DIFF
--- a/src/frontend/src/utils/urlHelper.test.ts
+++ b/src/frontend/src/utils/urlHelper.test.ts
@@ -47,7 +47,20 @@ describe('Shared urlHelper.ts', () => {
   test('returnUrlToMessagebox() with partyId uses redirect mechanism', () => {
     const host = 'tdd.apps.altinn.no';
     const result = returnUrlToMessagebox(host, 12345);
-    expect(result).toBe('https://altinn.no/ui/Reportee/ChangeReporteeAndRedirect?goTo=https%3A%2F%2Faf.altinn.no%2F&R=12345');
+    expect(result).toBe('https://am.ui.altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.altinn.no%2F');
+  });
+
+  test('returnUrlToMessagebox() with partyId uses redirect mechanism across environments', () => {
+    const partyId = 12345;
+    expect(returnUrlToMessagebox('tdd.apps.tt02.altinn.no', partyId)).toBe(
+      'https://am.ui.tt02.altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.tt02.altinn.no%2F',
+    );
+    expect(returnUrlToMessagebox('tdd.apps.at22.altinn.cloud', partyId)).toBe(
+      'https://am.ui.at22.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.at22.altinn.cloud%2F',
+    );
+    expect(returnUrlToMessagebox('tdd.apps.yt01.altinn.cloud', partyId)).toBe(
+      'https://am.ui.yt01.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.yt01.altinn.cloud%2F',
+    );
   });
 
   test('returnUrlToMessagebox() with dialogId returns inbox URL with dialogId', () => {
@@ -59,7 +72,7 @@ describe('Shared urlHelper.ts', () => {
   test('returnUrlToMessagebox() with partyId and dialogId uses redirect with dialogId', () => {
     const host = 'tdd.apps.altinn.no';
     const result = returnUrlToMessagebox(host, 12345, 'abc-123');
-    expect(result).toBe('https://altinn.no/ui/Reportee/ChangeReporteeAndRedirect?goTo=https%3A%2F%2Faf.altinn.no%2Finbox%2Fabc-123&R=12345');
+    expect(result).toBe('https://am.ui.altinn.no/accessmanagement/api/v1/reportee/changeandredirect?partyId=12345&goTo=https%3A%2F%2Faf.altinn.no%2Finbox%2Fabc-123');
   });
 
   test('returnUrlToMessagebox() for local environment', () => {

--- a/src/frontend/src/utils/urlHelper.ts
+++ b/src/frontend/src/utils/urlHelper.ts
@@ -32,6 +32,10 @@ function buildArbeidsflateUrl(altinnHost: string): string {
   return `https://af.${altinnHost}/`;
 }
 
+function buildAccessManagementBaseUrl(altinnHost: string): string {
+  return `https://am.ui.${altinnHost}/`;
+}
+
 export const returnBaseUrlToAltinn = (host: string): string | undefined => {
   const altinnHost = extractAltinnHost(host);
   if (!altinnHost) {
@@ -45,9 +49,8 @@ function buildArbeidsflateRedirectUrl(host: string, partyId?: number, dialogId?:
     return `http://${host}/`;
   }
 
-  const baseUrl = returnBaseUrlToAltinn(host);
   const altinnHost = extractAltinnHost(host);
-  if (!baseUrl || !altinnHost) {
+  if (!altinnHost) {
     return undefined;
   }
 
@@ -60,8 +63,9 @@ function buildArbeidsflateRedirectUrl(host: string, partyId?: number, dialogId?:
     return targetUrl;
   }
 
-  // Use A2 redirect mechanism with A3 arbeidsflate URL to maintain party context
-  return `${baseUrl}ui/Reportee/ChangeReporteeAndRedirect?goTo=${encodeURIComponent(targetUrl)}&R=${partyId}`;
+  // Use access management changeandredirect endpoint to switch party and redirect to A3 arbeidsflate
+  const amBaseUrl = buildAccessManagementBaseUrl(altinnHost);
+  return `${amBaseUrl}accessmanagement/api/v1/reportee/changeandredirect?partyId=${partyId}&goTo=${encodeURIComponent(targetUrl)}`;
 }
 
 export function getDialogIdFromDataValues(dataValues: unknown): string | undefined {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Bytt til Altinn 3 for partsbytte ved retur til innboks
  
  Når brukeren lukker kvitteringen og sendes tilbake til innboksen, brukte vi
  fortsatt det gamle Altinn 2-endepunktet for å bytte aktør (part). Dette er nå
  byttet til Altinn 3-varianten via access management.

  ### Hva er endret
  - **Før (A2):** `https://{host}/ui/Reportee/ChangeReporteeAndRedirect?goTo=...&R={partyId}`
  - **Nå (A3):** `https://am.ui.{host}/accessmanagement/api/v1/reportee/changeandredirect?partyId={partyId}&goTo=...`


  ### Detaljer
  - Ny hjelpefunksjon `buildAccessManagementBaseUrl` som bygger `am.ui.{host}`.
  - `buildArbeidsflateRedirectUrl` peker nå på `changeandredirect`-endepunktet.
  - Fungerer for alle miljøer: prod, tt02, at22 og yt01.

  ### Test
  - Oppdaterte tester til nytt URL-format.
  - La til egne tester som bekrefter riktig URL per miljø.

> [!NOTE]
  > **Trivy-skanneren feiler, men det er ikke relatert til denne PR-en.**
  >
  > Trivy (sårbarhetsskanning av Docker-imaget) feiler fordi base-imaget i `Dockerfile` har kjente HIGH/CRITICAL-sårbarheter med tilgjengelige fikser. Skanneren er satt opp til å feile på slike funn
  (`exit-code: 1`).
  >
  > Funnene kommer fra utdaterte base-images, ikke fra koden i denne PR-en:
  > - `aspnet:9.0.10-alpine3.22` (runtime) → .NET-runtime 9.0.10 (CVE-2026-26130, CVE-2026-42899) + Alpine-pakker openssl, musl, zlib
  > - `sdk:9.0.306-alpine3.22` (build)
  >
  > Dette ville feilet på alle PR-er akkurat nå. Fiks: bump base-imagene til nyeste 9.0-patch i en egen PR.
## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
