### PR TITLE
fix: upgrade openssl packages in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ COPY --from=build /app_output .
 COPY --from=build-receipt-frontend /build/dist/receipt.js ./wwwroot/receipt/js/react/receipt.js
 COPY --from=build-receipt-frontend /build/dist/receipt.css ./wwwroot/receipt/css/receipt.css
 
+RUN apk upgrade --no-cache libcrypto3 libssl3
+
 # setup the user and group
 # the user will have no password, using shell /bin/false and using the group dotnet
 RUN addgroup -g 3000 dotnet && adduser -u 1000 -G dotnet -D -s /bin/false dotnet


### PR DESCRIPTION
## What
- Upgrades `libcrypto3` and `libssl3` in the final Alpine runtime image during the Docker build.

## Why
- The container scan in https://github.com/Altinn/altinn-receipt/actions/runs/28120056643/job/83269386572?pr=656 fails because the pinned `mcr.microsoft.com/dotnet/aspnet:9.0.17-alpine3.23` image contains OpenSSL packages at `3.5.6-r0`.
- Alpine has fixed packages available as `3.5.7-r0`.

## Testing
- `docker build . --tag altinn-receipt:openssl-runtime-fix`
- `docker run --rm --entrypoint apk altinn-receipt:openssl-runtime-fix list --installed libcrypto3 libssl3`
  - `libcrypto3-3.5.7-r0 x86_64 {openssl} (Apache-2.0) [installed]`
  - `libssl3-3.5.7-r0 x86_64 {openssl} (Apache-2.0) [installed]`
- `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.65.0 image --exit-code 1 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH altinn-receipt:openssl-runtime-fix`
  - Reported `0` vulnerabilities for the Alpine and dotnet targets.
