### PR TITLE
fix: bump HelmRelease apiVersion to helm.toolkit.fluxcd.io/v2

### DIFF
--- a/.deploy/app.yaml
+++ b/.deploy/app.yaml
@@ -1,5 +1,5 @@
 # Only change this file to update the chart
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: altinn-receipt


### PR DESCRIPTION
Flux v2.6 removed the deprecated `helm.toolkit.fluxcd.io/v2beta1` API. The AKS `microsoft.flux` extension auto-upgrade (now shipping Flux v2.7) has reached some clusters, where reconciliation of this manifest now fails with:

    HelmRelease/default/altinn-receipt dry-run failed: no matches for kind "HelmRelease" in version "helm.toolkit.fluxcd.io/v2beta1"

Bump the apiVersion to the GA `v2`. No other spec fields change between the two versions for this manifest. `v2` has been served since Flux v2.3, so this applies cleanly on clusters that haven't received the extension upgrade yet — no rollout coordination needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)