### PR TITLE
fix: display name for SI user

### DIFF
--- a/src/frontend/src/utils/receipt.test.tsx
+++ b/src/frontend/src/utils/receipt.test.tsx
@@ -32,6 +32,11 @@ describe('utils > receipt', () => {
     orgNumber: 12345,
   } as IParty;
 
+  const partySelfIdentified = {
+    name: 'email@example.com',
+    partyTypeName: 3,
+  } as IParty;
+
   const language: ILanguage = {
     receipt_platform: {
       date_sent: 'Dato sendt',
@@ -71,6 +76,24 @@ describe('utils > receipt', () => {
       const expectedOrgResult = expectedResult;
       expectedOrgResult.Avsender = '12345-FIRMA AS';
       expect(result).toEqual(expectedOrgResult);
+    });
+
+    it('should use the party name as sender for a self-identified party without ssn or orgNumber', () => {
+      const result = getInstanceMetaDataObject(
+        instance,
+        partySelfIdentified,
+        language,
+        organisations,
+        application,
+        [],
+        'nb',
+      );
+      expect(result.Avsender).toEqual('email@example.com');
+    });
+
+    it('should return an empty sender when the party has no ssn, orgNumber or name', () => {
+      const result = getInstanceMetaDataObject(instance, {} as IParty, language, organisations, application, [], 'nb');
+      expect(result.Avsender).toEqual('');
     });
 
     it('should return empty object if no instance is provided', () => {

--- a/src/frontend/src/utils/receipt.ts
+++ b/src/frontend/src/utils/receipt.ts
@@ -13,8 +13,8 @@ const getDateSubmitted = (instance: IInstance, application: IApplication): strin
   if (instance.data && instance.data.length > 0) {
     const currentTaskData = getCurrentTaskData(application, instance);
     if (currentTaskData !== undefined) {
-      return instance.process?.ended 
-        ? formatDate(instance.process.ended) 
+      return instance.process?.ended
+        ? formatDate(instance.process.ended)
         : formatDate(currentTaskData.lastChanged);
     }
   }
@@ -32,7 +32,7 @@ const getSender = (party: IParty): string => {
   } else if (party.orgNumber) {
     return `${party.orgNumber}-${party.name}`;
   }
-  return '';
+  return party.name ?? '';
 };
 
 export const getInstanceMetaDataObject = (


### PR DESCRIPTION
## Description
Diaplay user name when org number and ssn is not available. SI users don't have either and have their email as name.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
