### PR TITLE
fix: downgrade `Azure.Monitor.OpenTelemetry.Exporter` to 1.8.2

### DIFF
--- a/src/backend/Altinn.Receipt/Altinn.Platform.Receipt.csproj
+++ b/src/backend/Altinn.Receipt/Altinn.Platform.Receipt.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.18" />
     <PackageReference Include="System.Net.Http.Json" Version="9.0.18" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.3" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />


### PR DESCRIPTION
## Description
Revert upgrade of `Azure.Monitor.OpenTelemetry.Exporter`


