### PR TITLE
chore: add csharpier for code formatting

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "csharpier": {
+      "version": "1.2.6",
+      "commands": [
+        "csharpier"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.csharpierignore
+++ b/.csharpierignore
@@ -1,0 +1,7 @@
+bin/
+obj/
+.git/
+*.xml
+*.csproj
+*.props
+*.targets

--- a/.csharpierrc.yaml
+++ b/.csharpierrc.yaml
@@ -1,0 +1,4 @@
+printWidth: 120
+useTabs: false
+tabWidth: 4
+endOfLine: auto

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Run this command to always ignore formatting commits in `git blame`
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# More info:
+# https://www.stefanjudis.com/today-i-learned/how-to-exclude-commits-from-git-blame/
+
+4aeb225ea5d39aa8f275fb3ac1d43d372d96d700 # style: format codebase with csharpier

--- a/.github/workflows/verify-formatting.yml
+++ b/.github/workflows/verify-formatting.yml
@@ -1,0 +1,36 @@
+name: Verify formatting
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'src/backend/**'
+      - 'test/**'
+      - '.csharpierrc.yaml'
+      - '.csharpierignore'
+      - '.config/dotnet-tools.json'
+      - 'Directory.Build.props'
+      - '.github/workflows/verify-formatting.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  verify-no-changes:
+    if: github.event.pull_request.user.login != 'renovate[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            9.0.x
+      - name: Install csharpier
+        run: dotnet tool restore
+      - name: Run csharpier
+        run: dotnet csharpier check .

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="CSharpier.MsBuild" Version="1.2.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/backend/Altinn.Receipt/Clients/HttpClientAccessor.cs
+++ b/src/backend/Altinn.Receipt/Clients/HttpClientAccessor.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
-
 using Altinn.Platform.Receipt.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -76,10 +75,7 @@ namespace Altinn.Platform.Receipt.Clients
 
         private HttpClient GetNewHttpClient(string apiEndpoint)
         {
-            HttpClient httpClient = new HttpClient
-            {
-                BaseAddress = new Uri(apiEndpoint)
-            };
+            HttpClient httpClient = new HttpClient { BaseAddress = new Uri(apiEndpoint) };
 
             httpClient.DefaultRequestHeaders.Add(SubscriptionKeyHeaderName, _platformSettings.SubscriptionKey);
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/backend/Altinn.Receipt/Configuration/PlatformSettings.cs
+++ b/src/backend/Altinn.Receipt/Configuration/PlatformSettings.cs
@@ -33,7 +33,7 @@ public class PlatformSettings
     public string SubscriptionKey { get; set; }
 
     /// <summary>
-    /// The name of the subscription header for Api management. 
+    /// The name of the subscription header for Api management.
     /// </summary>
     public string SubscriptionKeyHeaderName { get; set; } = "Ocp-Apim-Subscription-Key";
 }

--- a/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
+++ b/src/backend/Altinn.Receipt/Controllers/ReceiptController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Receipt.Configuration;
 using Altinn.Platform.Receipt.Helpers;
@@ -11,7 +10,6 @@ using Altinn.Platform.Receipt.Services.Interfaces;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using AltinnCore.Authentication.Constants;
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -49,7 +47,8 @@ namespace Altinn.Platform.Receipt
             IProfile profile,
             ILogger<ReceiptController> logger,
             IHttpContextAccessor httpContextAccessor,
-            IOptions<GeneralSettings> generalSettings)
+            IOptions<GeneralSettings> generalSettings
+        )
         {
             _register = register;
             _storage = storage;
@@ -70,7 +69,11 @@ namespace Altinn.Platform.Receipt
         [Route("receipt/{instanceOwnerId}/{instanceId}")]
         public IActionResult Index(int instanceOwnerId, Guid instanceId, [FromQuery] string returnUrl = null)
         {
-            _logger.LogInformation("Getting receipt for: {InstanceOwnerId} for instance with id: {InstanceId}.", instanceOwnerId, instanceId);
+            _logger.LogInformation(
+                "Getting receipt for: {InstanceOwnerId} for instance with id: {InstanceId}.",
+                instanceOwnerId,
+                instanceId
+            );
             return View("receipt");
         }
 
@@ -82,8 +85,10 @@ namespace Altinn.Platform.Receipt
         [Route("receipt/api/v1/users/current")]
         public async Task<IActionResult> GetCurrentUser()
         {
-            string userIdString = Request.HttpContext.User.Claims.Where(c => c.Type == AltinnCoreClaimTypes.UserId)
-           .Select(c => c.Value).SingleOrDefault();
+            string userIdString = Request
+                .HttpContext.User.Claims.Where(c => c.Type == AltinnCoreClaimTypes.UserId)
+                .Select(c => c.Value)
+                .SingleOrDefault();
 
             if (string.IsNullOrEmpty(userIdString))
             {
@@ -111,7 +116,9 @@ namespace Altinn.Platform.Receipt
         [Route("receipt/api/v1/users/current/language")]
         public IActionResult GetCurrentUserLanguage()
         {
-            string language = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(_httpContextAccessor.HttpContext.Request.Cookies["altinnPersistentContext"]);
+            string language = LanguageHelper.GetLanguageFromAltinnPersistenceCookie(
+                _httpContextAccessor.HttpContext.Request.Cookies["altinnPersistentContext"]
+            );
 
             try
             {
@@ -134,7 +141,11 @@ namespace Altinn.Platform.Receipt
         /// <returns>An extended instance including instance metadata and potentially party data.</returns>
         [HttpGet]
         [Route("receipt/api/v1/instances/{instanceOwnerId}/{instanceGuid}")]
-        public async Task<ActionResult> GetInstanceIncludeParty(int instanceOwnerId, Guid instanceGuid, bool includeParty = false)
+        public async Task<ActionResult> GetInstanceIncludeParty(
+            int instanceOwnerId,
+            Guid instanceGuid,
+            bool includeParty = false
+        )
         {
             ExtendedInstance result = new ExtendedInstance();
 

--- a/src/backend/Altinn.Receipt/Extensions/HostingExtensions.cs
+++ b/src/backend/Altinn.Receipt/Extensions/HostingExtensions.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -32,10 +31,10 @@ public static class HostingExtensions
         var shutdownTimeout = TimeSpan.FromSeconds(20);
 
         builder.Services.AddSingleton<IHostLifetime>(sp =>
-            ActivatorUtilities.CreateInstance<AppHostLifetime>(sp, shutdownDelay));
+            ActivatorUtilities.CreateInstance<AppHostLifetime>(sp, shutdownDelay)
+        );
 
-        builder.Services.Configure<HostOptions>(options =>
-            options.ShutdownTimeout = shutdownTimeout);
+        builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = shutdownTimeout);
 
         return builder;
     }
@@ -52,7 +51,8 @@ public static class HostingExtensions
             ILogger<AppHostLifetime> logger,
             IHostEnvironment environment,
             IHostApplicationLifetime applicationLifetime,
-            TimeSpan delay)
+            TimeSpan delay
+        )
         {
             _logger = logger;
             _environment = environment;
@@ -67,9 +67,7 @@ public static class HostingExtensions
 
         public Task WaitForStartAsync(CancellationToken cancellationToken)
         {
-            Debug.Assert(
-                !_environment.IsDevelopment(),
-                "We don't need graceful shutdown in development environments");
+            Debug.Assert(!_environment.IsDevelopment(), "We don't need graceful shutdown in development environments");
 
             PosixSignalRegistration sigint = null;
             PosixSignalRegistration sigquit = null;
@@ -105,9 +103,7 @@ public static class HostingExtensions
 
         private void HandleSignal(PosixSignalContext ctx)
         {
-            _logger.LogInformation(
-                "Received shutdown signal: {Signal}, delaying shutdown",
-                ctx.Signal);
+            _logger.LogInformation("Received shutdown signal: {Signal}, delaying shutdown", ctx.Signal);
             ctx.Cancel = true;
 
             _ = Task.Delay(_delay)
@@ -117,7 +113,8 @@ public static class HostingExtensions
                         _logger.LogInformation("Starting host shutdown...");
                         _applicationLifetime.StopApplication();
                     },
-                    TaskScheduler.Default);
+                    TaskScheduler.Default
+                );
         }
 
         private void TryDispose(IDisposable disposable)
@@ -128,10 +125,7 @@ public static class HostingExtensions
             }
             catch (Exception ex)
             {
-                _logger.LogError(
-                    ex,
-                    "Error during disposal of {Type}",
-                    disposable?.GetType().FullName);
+                _logger.LogError(ex, "Error during disposal of {Type}", disposable?.GetType().FullName);
             }
         }
     }

--- a/src/backend/Altinn.Receipt/Extensions/HttpClientExtension.cs
+++ b/src/backend/Altinn.Receipt/Extensions/HttpClientExtension.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace Altinn.Platform.Receipt.Extensions
 {
     /// <summary>
-    /// This extentsion is created to make it easy to add a bearer token to a httprequests. 
+    /// This extentsion is created to make it easy to add a bearer token to a httprequests.
     /// </summary>
     public static class HttpClientExtension
     {
@@ -18,7 +18,13 @@ namespace Altinn.Platform.Receipt.Extensions
         /// <param name="content">The http content</param>
         /// <param name="platformAccessToken">The platformAccess tokens</param>
         /// <returns>A HttpResponseMessage</returns>
-        public static Task<HttpResponseMessage> PostAsync(this HttpClient httpClient, string authorizationToken, string requestUri, HttpContent content, string platformAccessToken = null)
+        public static Task<HttpResponseMessage> PostAsync(
+            this HttpClient httpClient,
+            string authorizationToken,
+            string requestUri,
+            HttpContent content,
+            string platformAccessToken = null
+        )
         {
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
             request.Headers.Add("Authorization", "Bearer " + authorizationToken);
@@ -40,7 +46,13 @@ namespace Altinn.Platform.Receipt.Extensions
         /// <param name="content">The http content</param>
         /// <param name="platformAccessToken">The platformAccess tokens</param>
         /// <returns>A HttpResponseMessage</returns>
-        public static Task<HttpResponseMessage> PutAsync(this HttpClient httpClient, string authorizationToken, string requestUri, HttpContent content, string platformAccessToken = null)
+        public static Task<HttpResponseMessage> PutAsync(
+            this HttpClient httpClient,
+            string authorizationToken,
+            string requestUri,
+            HttpContent content,
+            string platformAccessToken = null
+        )
         {
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Put, requestUri);
             request.Headers.Add("Authorization", "Bearer " + authorizationToken);
@@ -61,7 +73,12 @@ namespace Altinn.Platform.Receipt.Extensions
         /// <param name="requestUri">The request Uri</param>
         /// <param name="platformAccessToken">The platformAccess tokens</param>
         /// <returns>A HttpResponseMessage</returns>
-        public static Task<HttpResponseMessage> GetAsync(this HttpClient httpClient, string authorizationToken, string requestUri, string platformAccessToken = null)
+        public static Task<HttpResponseMessage> GetAsync(
+            this HttpClient httpClient,
+            string authorizationToken,
+            string requestUri,
+            string platformAccessToken = null
+        )
         {
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
             request.Headers.Add("Authorization", "Bearer " + authorizationToken);
@@ -81,7 +98,12 @@ namespace Altinn.Platform.Receipt.Extensions
         /// <param name="requestUri">The request Uri</param>
         /// <param name="platformAccessToken">The platformAccess tokens</param>
         /// <returns>A HttpResponseMessage</returns>
-        public static Task<HttpResponseMessage> DeleteAsync(this HttpClient httpClient, string authorizationToken, string requestUri, string platformAccessToken = null)
+        public static Task<HttpResponseMessage> DeleteAsync(
+            this HttpClient httpClient,
+            string authorizationToken,
+            string requestUri,
+            string platformAccessToken = null
+        )
         {
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Delete, requestUri);
             request.Headers.Add("Authorization", "Bearer " + authorizationToken);

--- a/src/backend/Altinn.Receipt/Health/HealthCheck.cs
+++ b/src/backend/Altinn.Receipt/Health/HealthCheck.cs
@@ -6,7 +6,7 @@ namespace Altinn.Platform.Receipt.Health
 {
     /// <summary>
     /// Health check service configured in startup https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks
-    /// Listen to 
+    /// Listen to
     /// </summary>
     public class HealthCheck : IHealthCheck
     {
@@ -16,10 +16,12 @@ namespace Altinn.Platform.Receipt.Health
         /// <param name="context">The healtcheck context</param>
         /// <param name="cancellationToken">The cancellationtoken</param>
         /// <returns>The health check result</returns>
-        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default
+        )
         {
-            return Task.FromResult(
-                HealthCheckResult.Healthy("A healthy result."));
+            return Task.FromResult(HealthCheckResult.Healthy("A healthy result."));
         }
     }
 }

--- a/src/backend/Altinn.Receipt/Helpers/JsonSerializerOptionsProvider.cs
+++ b/src/backend/Altinn.Receipt/Helpers/JsonSerializerOptionsProvider.cs
@@ -11,13 +11,14 @@ public static class JsonSerializerOptionsProvider
     /// <summary>
     /// Standard serializer options
     /// </summary>
-    public static JsonSerializerOptions Options { get; } = new()
-    {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true,
-        NumberHandling = JsonNumberHandling.AllowReadingFromString,
-        
-        Converters = { new JsonStringEnumConverter() }
-    };
+    public static JsonSerializerOptions Options { get; } =
+        new()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            NumberHandling = JsonNumberHandling.AllowReadingFromString,
+
+            Converters = { new JsonStringEnumConverter() },
+        };
 }

--- a/src/backend/Altinn.Receipt/Helpers/LanguageHelper.cs
+++ b/src/backend/Altinn.Receipt/Helpers/LanguageHelper.cs
@@ -31,7 +31,7 @@ public static class LanguageHelper
         {
             return "nn";
         }
-        
+
         return string.Empty;
     }
 }

--- a/src/backend/Altinn.Receipt/Helpers/PlatformHttpException.cs
+++ b/src/backend/Altinn.Receipt/Helpers/PlatformHttpException.cs
@@ -19,7 +19,8 @@ namespace Altinn.Platform.Receipt.Helpers
         /// </summary>
         /// <param name="response">the response</param>
         /// <param name="message">the message</param>
-        public PlatformHttpException(HttpResponseMessage response, string message) : base(message)
+        public PlatformHttpException(HttpResponseMessage response, string message)
+            : base(message)
         {
             Response = response;
         }

--- a/src/backend/Altinn.Receipt/Program.cs
+++ b/src/backend/Altinn.Receipt/Program.cs
@@ -3,22 +3,17 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
-
 using Altinn.Common.AccessTokenClient.Services;
-
 using Altinn.Platform.Receipt.Configuration;
 using Altinn.Platform.Receipt.Extensions;
 using Altinn.Platform.Receipt.Health;
 using Altinn.Platform.Receipt.Services;
 using Altinn.Platform.Receipt.Services.Interfaces;
 using Altinn.Platform.Receipt.Telemetry;
-
 using AltinnCore.Authentication.JwtCookie;
-
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Security.KeyVault.Secrets;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -70,9 +65,7 @@ void ConfigureWebHostCreationLogging()
 {
     var logFactory = LoggerFactory.Create(builder =>
     {
-        builder
-            .AddFilter("Altinn.Platform.Receipt.Program", LogLevel.Debug)
-            .AddConsole();
+        builder.AddFilter("Altinn.Platform.Receipt.Program", LogLevel.Debug).AddConsole();
     });
 
     logger = logFactory.CreateLogger<Program>();
@@ -82,14 +75,22 @@ async Task SetConfigurationProviders(ConfigurationManager config)
 {
     string basePath = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
     config.SetBasePath(basePath);
-    config.AddJsonFile(basePath + "altinn-appsettings/altinn-dbsettings-secret.json", optional: true, reloadOnChange: true);
+    config.AddJsonFile(
+        basePath + "altinn-appsettings/altinn-dbsettings-secret.json",
+        optional: true,
+        reloadOnChange: true
+    );
     if (basePath == "/")
     {
         config.AddJsonFile(basePath + "app/appsettings.json", optional: false, reloadOnChange: true);
     }
     else
     {
-        config.AddJsonFile(Directory.GetCurrentDirectory() + "/appsettings.json", optional: false, reloadOnChange: true);
+        config.AddJsonFile(
+            Directory.GetCurrentDirectory() + "/appsettings.json",
+            optional: false,
+            reloadOnChange: true
+        );
     }
 
     config.AddEnvironmentVariables();
@@ -127,18 +128,24 @@ async Task ConnectToKeyVaultAndSetApplicationInsights(ConfigurationManager confi
 
 void AddAzureMonitorTelemetryExporters(IServiceCollection services, string applicationInsightsConnectionString)
 {
-    services.Configure<OpenTelemetryLoggerOptions>(logging => logging.AddAzureMonitorLogExporter(o =>
-    {
-        o.ConnectionString = applicationInsightsConnectionString;
-    }));
-    services.ConfigureOpenTelemetryMeterProvider(metrics => metrics.AddAzureMonitorMetricExporter(o =>
-    {
-        o.ConnectionString = applicationInsightsConnectionString;
-    }));
-    services.ConfigureOpenTelemetryTracerProvider(tracing => tracing.AddAzureMonitorTraceExporter(o =>
-    {
-        o.ConnectionString = applicationInsightsConnectionString;
-    }));
+    services.Configure<OpenTelemetryLoggerOptions>(logging =>
+        logging.AddAzureMonitorLogExporter(o =>
+        {
+            o.ConnectionString = applicationInsightsConnectionString;
+        })
+    );
+    services.ConfigureOpenTelemetryMeterProvider(metrics =>
+        metrics.AddAzureMonitorMetricExporter(o =>
+        {
+            o.ConnectionString = applicationInsightsConnectionString;
+        })
+    );
+    services.ConfigureOpenTelemetryTracerProvider(tracing =>
+        tracing.AddAzureMonitorTraceExporter(o =>
+        {
+            o.ConnectionString = applicationInsightsConnectionString;
+        })
+    );
 }
 
 void ConfigureServices(IServiceCollection services, IConfiguration config)
@@ -148,15 +155,13 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
         KeyValuePair.Create("service.name", (object)"platform-receipt"),
     };
 
-    services.AddOpenTelemetry()
+    services
+        .AddOpenTelemetry()
         .ConfigureResource(resourceBuilder => resourceBuilder.AddAttributes(attributes))
         .WithMetrics(metrics =>
         {
             metrics.AddAspNetCoreInstrumentation();
-            metrics.AddMeter(
-                "Microsoft.AspNetCore.Hosting",
-                "Microsoft.AspNetCore.Server.Kestrel",
-                "System.Net.Http");
+            metrics.AddMeter("Microsoft.AspNetCore.Hosting", "Microsoft.AspNetCore.Server.Kestrel", "System.Net.Http");
         })
         .WithTracing(tracing =>
         {
@@ -182,26 +187,30 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     GeneralSettings generalSettings = config.GetSection("GeneralSettings").Get<GeneralSettings>();
     services.Configure<GeneralSettings>(config.GetSection("GeneralSettings"));
 
-    services.AddAuthentication(JwtCookieDefaults.AuthenticationScheme)
-        .AddJwtCookie(JwtCookieDefaults.AuthenticationScheme, options =>
-        {
-            options.JwtCookieName = generalSettings.RuntimeCookieName;
-            options.MetadataAddress = generalSettings.OpenIdWellKnownEndpoint;
-            options.TokenValidationParameters = new TokenValidationParameters
+    services
+        .AddAuthentication(JwtCookieDefaults.AuthenticationScheme)
+        .AddJwtCookie(
+            JwtCookieDefaults.AuthenticationScheme,
+            options =>
             {
-                ValidateIssuerSigningKey = true,
-                ValidateIssuer = false,
-                ValidateAudience = false,
-                RequireExpirationTime = true,
-                ValidateLifetime = true,
-                ClockSkew = TimeSpan.Zero
-            };
+                options.JwtCookieName = generalSettings.RuntimeCookieName;
+                options.MetadataAddress = generalSettings.OpenIdWellKnownEndpoint;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuerSigningKey = true,
+                    ValidateIssuer = false,
+                    ValidateAudience = false,
+                    RequireExpirationTime = true,
+                    ValidateLifetime = true,
+                    ClockSkew = TimeSpan.Zero,
+                };
 
-            if (builder.Environment.IsDevelopment())
-            {
-                options.RequireHttpsMetadata = false;
+                if (builder.Environment.IsDevelopment())
+                {
+                    options.RequireHttpsMetadata = false;
+                }
             }
-        });
+        );
 
     services.AddSingleton(config);
     services.AddHttpClient<IRegister, RegisterWrapper>();
@@ -264,9 +273,7 @@ void Configure(IConfiguration config)
         name: "languageRoute",
         pattern: "receipt/api/v1/{controller}/{action=Index}",
         defaults: new { controller = "Language" },
-        constraints: new
-        {
-            controller = "Language",
-        });
+        constraints: new { controller = "Language" }
+    );
     app.MapHealthChecks("/health");
 }

--- a/src/backend/Altinn.Receipt/Services/Interfaces/IProfile.cs
+++ b/src/backend/Altinn.Receipt/Services/Interfaces/IProfile.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-
 using Altinn.Platform.Profile.Models;
 
 namespace Altinn.Platform.Receipt.Services.Interfaces

--- a/src/backend/Altinn.Receipt/Services/Interfaces/IRegister.cs
+++ b/src/backend/Altinn.Receipt/Services/Interfaces/IRegister.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-
 using Altinn.Platform.Register.Models;
 
 namespace Altinn.Platform.Receipt.Services.Interfaces
@@ -14,6 +13,6 @@ namespace Altinn.Platform.Receipt.Services.Interfaces
         /// </summary>
         /// <param name="partyId">The party id</param>
         /// <returns>The party object</returns>
-        public Task<Party> GetParty(int partyId);        
+        public Task<Party> GetParty(int partyId);
     }
 }

--- a/src/backend/Altinn.Receipt/Services/Interfaces/IStorage.cs
+++ b/src/backend/Altinn.Receipt/Services/Interfaces/IStorage.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.Platform.Receipt.Services.Interfaces

--- a/src/backend/Altinn.Receipt/Services/ProfileWrapper.cs
+++ b/src/backend/Altinn.Receipt/Services/ProfileWrapper.cs
@@ -3,15 +3,12 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
-
 using Altinn.Common.AccessTokenClient.Services;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Receipt.Configuration;
 using Altinn.Platform.Receipt.Extensions;
 using Altinn.Platform.Receipt.Helpers;
-
 using AltinnCore.Authentication.Utils;
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -29,10 +26,18 @@ namespace Altinn.Platform.Receipt.Services.Interfaces
         /// <summary>
         /// Initializes a new instance of the <see cref="ProfileWrapper"/> class
         /// </summary>
-        public ProfileWrapper(HttpClient httpClient, IHttpContextAccessor httpContextAccessor, IOptions<PlatformSettings> platformSettings, IAccessTokenGenerator accessTokenGenerator)
+        public ProfileWrapper(
+            HttpClient httpClient,
+            IHttpContextAccessor httpContextAccessor,
+            IOptions<PlatformSettings> platformSettings,
+            IAccessTokenGenerator accessTokenGenerator
+        )
         {
             httpClient.BaseAddress = new Uri(platformSettings.Value.ApiProfileEndpoint);
-            httpClient.DefaultRequestHeaders.Add(platformSettings.Value.SubscriptionKeyHeaderName, platformSettings.Value.SubscriptionKey);
+            httpClient.DefaultRequestHeaders.Add(
+                platformSettings.Value.SubscriptionKeyHeaderName,
+                platformSettings.Value.SubscriptionKey
+            );
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _client = httpClient;
             _contextaccessor = httpContextAccessor;
@@ -45,11 +50,15 @@ namespace Altinn.Platform.Receipt.Services.Interfaces
             string token = JwtTokenUtil.GetTokenFromContext(_contextaccessor.HttpContext, "AltinnStudioRuntime");
             string url = $"users/{userId}";
 
-            HttpResponseMessage response = await _client.GetAsync(token, url, _accessTokenGenerator.GenerateAccessToken("platform", "receipt"));
+            HttpResponseMessage response = await _client.GetAsync(
+                token,
+                url,
+                _accessTokenGenerator.GenerateAccessToken("platform", "receipt")
+            );
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                return await response.Content.ReadFromJsonAsync<UserProfile>(JsonSerializerOptionsProvider.Options);             
+                return await response.Content.ReadFromJsonAsync<UserProfile>(JsonSerializerOptionsProvider.Options);
             }
 
             throw new PlatformHttpException(response, string.Empty);

--- a/src/backend/Altinn.Receipt/Services/RegisterWrapper.cs
+++ b/src/backend/Altinn.Receipt/Services/RegisterWrapper.cs
@@ -3,16 +3,13 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
-
 using Altinn.Common.AccessTokenClient.Services;
 using Altinn.Platform.Receipt.Configuration;
 using Altinn.Platform.Receipt.Extensions;
 using Altinn.Platform.Receipt.Helpers;
 using Altinn.Platform.Receipt.Services.Interfaces;
 using Altinn.Platform.Register.Models;
-
 using AltinnCore.Authentication.Utils;
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -30,10 +27,18 @@ namespace Altinn.Platform.Receipt.Services
         /// <summary>
         /// Initializes a new instance of the <see cref="RegisterWrapper"/> class
         /// </summary>
-        public RegisterWrapper(HttpClient httpClient, IHttpContextAccessor httpContextAccessor, IOptions<PlatformSettings> platformSettings, IAccessTokenGenerator accessTokenGenerator)
+        public RegisterWrapper(
+            HttpClient httpClient,
+            IHttpContextAccessor httpContextAccessor,
+            IOptions<PlatformSettings> platformSettings,
+            IAccessTokenGenerator accessTokenGenerator
+        )
         {
             httpClient.BaseAddress = new Uri(platformSettings.Value.ApiRegisterEndpoint);
-            httpClient.DefaultRequestHeaders.Add(platformSettings.Value.SubscriptionKeyHeaderName, platformSettings.Value.SubscriptionKey);
+            httpClient.DefaultRequestHeaders.Add(
+                platformSettings.Value.SubscriptionKeyHeaderName,
+                platformSettings.Value.SubscriptionKey
+            );
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _client = httpClient;
             _contextaccessor = httpContextAccessor;
@@ -46,7 +51,11 @@ namespace Altinn.Platform.Receipt.Services
             string token = JwtTokenUtil.GetTokenFromContext(_contextaccessor.HttpContext, "AltinnStudioRuntime");
             string url = $"parties/{partyId}";
 
-            HttpResponseMessage response = await _client.GetAsync(token, url, _accessTokenGenerator.GenerateAccessToken("platform", "receipt"));
+            HttpResponseMessage response = await _client.GetAsync(
+                token,
+                url,
+                _accessTokenGenerator.GenerateAccessToken("platform", "receipt")
+            );
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {

--- a/src/backend/Altinn.Receipt/Services/StorageWrapper.cs
+++ b/src/backend/Altinn.Receipt/Services/StorageWrapper.cs
@@ -3,14 +3,11 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
-
 using Altinn.Platform.Receipt.Configuration;
 using Altinn.Platform.Receipt.Extensions;
 using Altinn.Platform.Receipt.Helpers;
 using Altinn.Platform.Storage.Interface.Models;
-
 using AltinnCore.Authentication.Utils;
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -27,10 +24,17 @@ namespace Altinn.Platform.Receipt.Services.Interfaces
         /// <summary>
         /// Initializes a new instance of the <see cref="StorageWrapper"/> class
         /// </summary>
-        public StorageWrapper(HttpClient httpClient, IHttpContextAccessor httpContextAccessor, IOptions<PlatformSettings> platformSettings)
+        public StorageWrapper(
+            HttpClient httpClient,
+            IHttpContextAccessor httpContextAccessor,
+            IOptions<PlatformSettings> platformSettings
+        )
         {
             httpClient.BaseAddress = new Uri(platformSettings.Value.ApiStorageEndpoint);
-            httpClient.DefaultRequestHeaders.Add(platformSettings.Value.SubscriptionKeyHeaderName, platformSettings.Value.SubscriptionKey);
+            httpClient.DefaultRequestHeaders.Add(
+                platformSettings.Value.SubscriptionKeyHeaderName,
+                platformSettings.Value.SubscriptionKey
+            );
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _client = httpClient;
             _contextAccessor = httpContextAccessor;

--- a/src/backend/Altinn.Receipt/Telemetry/RequestFilterProcessor.cs
+++ b/src/backend/Altinn.Receipt/Telemetry/RequestFilterProcessor.cs
@@ -78,7 +78,8 @@ namespace Altinn.Platform.Receipt.Telemetry
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestFilterProcessor"/> class.
         /// </summary>
-        public RequestFilterProcessor(IHttpContextAccessor httpContextAccessor = null) : base()
+        public RequestFilterProcessor(IHttpContextAccessor httpContextAccessor = null)
+            : base()
         {
             _httpContextAccessor = httpContextAccessor;
         }
@@ -112,7 +113,12 @@ namespace Altinn.Platform.Receipt.Telemetry
         {
             if (activity.OperationName == RequestKind && _httpContextAccessor.HttpContext is not null)
             {
-                if (_httpContextAccessor.HttpContext.Request.Headers.TryGetValue("X-Forwarded-For", out StringValues ipAddress))
+                if (
+                    _httpContextAccessor.HttpContext.Request.Headers.TryGetValue(
+                        "X-Forwarded-For",
+                        out StringValues ipAddress
+                    )
+                )
                 {
                     activity.SetTag("ipAddress", ipAddress.FirstOrDefault());
                 }
@@ -132,7 +138,7 @@ namespace Altinn.Platform.Receipt.Telemetry
             return localpath switch
             {
                 var path when path.TrimEnd('/').EndsWith("/health", StringComparison.OrdinalIgnoreCase) => true,
-                _ => false
+                _ => false,
             };
         }
     }

--- a/test/Extensions/HostingExtensionsTests.cs
+++ b/test/Extensions/HostingExtensionsTests.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Linq;
-
 using Altinn.Platform.Receipt.Extensions;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-
 using Xunit;
 
 namespace Altinn.Platform.Receipt.UnitTest.Extensions;
@@ -18,7 +15,8 @@ public class HostingExtensionsTests
     public void UseGracefulShutdown_Production_ConfiguresHostLifetimeAndShutdownTimeout()
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder(
-            new WebApplicationOptions { EnvironmentName = Environments.Production });
+            new WebApplicationOptions { EnvironmentName = Environments.Production }
+        );
 
         builder.UseGracefulShutdown();
 
@@ -34,14 +32,13 @@ public class HostingExtensionsTests
     public void UseGracefulShutdown_Development_DoesNotReplaceHostLifetime()
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder(
-            new WebApplicationOptions { EnvironmentName = Environments.Development });
-        int registrationsBefore = builder.Services.Count(descriptor =>
-            descriptor.ServiceType == typeof(IHostLifetime));
+            new WebApplicationOptions { EnvironmentName = Environments.Development }
+        );
+        int registrationsBefore = builder.Services.Count(descriptor => descriptor.ServiceType == typeof(IHostLifetime));
 
         builder.UseGracefulShutdown();
 
-        int registrationsAfter = builder.Services.Count(descriptor =>
-            descriptor.ServiceType == typeof(IHostLifetime));
+        int registrationsAfter = builder.Services.Count(descriptor => descriptor.ServiceType == typeof(IHostLifetime));
 
         Assert.Equal(registrationsBefore, registrationsAfter);
     }

--- a/test/Health/HealthCheckTests.cs
+++ b/test/Health/HealthCheckTests.cs
@@ -1,18 +1,15 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-
 using Altinn.Platform.Receipt.Health;
-
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
-
 using Xunit;
 
 namespace Altinn.Platform.Receipt.UnitTest;
 
 /// <summary>
-/// Health check 
+/// Health check
 /// </summary>
 public class HealthCheckTests : IClassFixture<WebApplicationFactory<HealthCheck>>
 {
@@ -36,9 +33,7 @@ public class HealthCheckTests : IClassFixture<WebApplicationFactory<HealthCheck>
     {
         HttpClient client = GetTestClient();
 
-        HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/health")
-        {
-        };
+        HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/health") { };
 
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
         await response.Content.ReadAsStringAsync();
@@ -47,12 +42,12 @@ public class HealthCheckTests : IClassFixture<WebApplicationFactory<HealthCheck>
 
     private HttpClient GetTestClient()
     {
-        HttpClient client = _factory.WithWebHostBuilder(builder =>
-        {
-            builder.ConfigureTestServices(services =>
+        HttpClient client = _factory
+            .WithWebHostBuilder(builder =>
             {
-            });
-        }).CreateClient();
+                builder.ConfigureTestServices(services => { });
+            })
+            .CreateClient();
 
         return client;
     }

--- a/test/HttpClientAccessorTest.cs
+++ b/test/HttpClientAccessorTest.cs
@@ -1,9 +1,7 @@
 using System.Net.Http;
 using Altinn.Platform.Receipt.Clients;
 using Altinn.Platform.Receipt.Configuration;
-
 using Microsoft.Extensions.Options;
-
 using Xunit;
 
 namespace Altinn.Platform.Receipt.Tests;
@@ -20,14 +18,17 @@ public class HttpClientAccessorTest
     public void TC01_InstantiateClients_ValidateParameters()
     {
         // Arrange
-        _httpClientAccessor = new HttpClientAccessor(Options.Create(
-            new PlatformSettings
-            {
-                ApiProfileEndpoint = profileEndpoint,
-                ApiRegisterEndpoint = registerEndpoint,
-                ApiStorageEndpoint = storageEndpoint,
-                SubscriptionKey = subscriptionKey
-            }));
+        _httpClientAccessor = new HttpClientAccessor(
+            Options.Create(
+                new PlatformSettings
+                {
+                    ApiProfileEndpoint = profileEndpoint,
+                    ApiRegisterEndpoint = registerEndpoint,
+                    ApiStorageEndpoint = storageEndpoint,
+                    SubscriptionKey = subscriptionKey,
+                }
+            )
+        );
 
         // Act
         HttpClient profileClient = _httpClientAccessor.ProfileClient;

--- a/test/Mocks/ConfigurationManagerStub.cs
+++ b/test/Mocks/ConfigurationManagerStub.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
@@ -39,7 +38,9 @@ namespace Altinn.Platform.Receipt.Tests.Mocks
         {
             List<SecurityKey> signingKeys = new List<SecurityKey>();
 
-            X509Certificate2 cert = X509CertificateLoader.LoadCertificateFromFile("selfSignedTestCertificatePublic.cer");
+            X509Certificate2 cert = X509CertificateLoader.LoadCertificateFromFile(
+                "selfSignedTestCertificatePublic.cer"
+            );
             SecurityKey key = new X509SecurityKey(cert);
 
             signingKeys.Add(key);

--- a/test/Mocks/JwtCookiePostConfigureOptionsStub.cs
+++ b/test/Mocks/JwtCookiePostConfigureOptionsStub.cs
@@ -1,7 +1,5 @@
 using System;
-
 using AltinnCore.Authentication.JwtCookie;
-
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.Options;
 

--- a/test/Mocks/JwtTokenMock.cs
+++ b/test/Mocks/JwtTokenMock.cs
@@ -2,7 +2,6 @@ using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
-
 using Microsoft.IdentityModel.Tokens;
 
 namespace Altinn.Platform.Receipt.Tests.Mocks
@@ -25,7 +24,7 @@ namespace Altinn.Platform.Receipt.Tests.Mocks
                 Subject = new ClaimsIdentity(principal.Identity),
                 Expires = DateTime.UtcNow.AddSeconds(3600),
                 SigningCredentials = GetSigningCredentials(),
-                Audience = "altinn.no"
+                Audience = "altinn.no",
             };
 
             SecurityToken token = tokenHandler.CreateToken(tokenDescriptor);
@@ -36,7 +35,10 @@ namespace Altinn.Platform.Receipt.Tests.Mocks
 
         private static SigningCredentials GetSigningCredentials()
         {
-            X509Certificate2 cert = X509CertificateLoader.LoadPkcs12FromFile("selfSignedTestCertificate.pfx", "qwer1234");
+            X509Certificate2 cert = X509CertificateLoader.LoadPkcs12FromFile(
+                "selfSignedTestCertificate.pfx",
+                "qwer1234"
+            );
             return new X509SigningCredentials(cert, SecurityAlgorithms.RsaSha256);
         }
     }

--- a/test/ReceiptControllerTests.cs
+++ b/test/ReceiptControllerTests.cs
@@ -5,24 +5,20 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Threading.Tasks;
-
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Receipt.Helpers;
 using Altinn.Platform.Receipt.Model;
 using Altinn.Platform.Receipt.Services.Interfaces;
 using Altinn.Platform.Receipt.Tests.Mocks;
 using Altinn.Platform.Receipt.Tests.Testdata;
-
 using AltinnCore.Authentication.Constants;
 using AltinnCore.Authentication.JwtCookie;
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -55,9 +51,7 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
     [Fact]
     public async Task GetCurrentUser_TC01_AuthenticatedUser()
     {
-        _profileMock
-       .Setup(p => p.GetUser(It.IsAny<int>()))
-       .ReturnsAsync(UserProfiles.User1);
+        _profileMock.Setup(p => p.GetUser(It.IsAny<int>())).ReturnsAsync(UserProfiles.User1);
 
         HttpClient client = GetTestClient(_registerMock, _storageMock, _profileMock);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetUserToken(3));
@@ -82,13 +76,18 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         HttpResponseMessage response = await client.GetAsync(url);
         Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
     }
-    
+
     [Fact]
     public async Task GetCurrentUser_TC03_ServiceThrowsException()
     {
         _profileMock
-         .Setup(p => p.GetUser(It.IsAny<int>()))
-         .Throws(new PlatformHttpException(new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.Forbidden }, string.Empty));
+            .Setup(p => p.GetUser(It.IsAny<int>()))
+            .Throws(
+                new PlatformHttpException(
+                    new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.Forbidden },
+                    string.Empty
+                )
+            );
 
         HttpClient client = GetTestClient(_registerMock, _storageMock, _profileMock);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetUserToken(3));
@@ -102,9 +101,7 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
     [Fact]
     public async Task GetCurrentUserLanguage_TC01_NoCookie_ReturnsNoContent()
     {
-        _profileMock
-       .Setup(p => p.GetUser(It.IsAny<int>()))
-       .ReturnsAsync(UserProfiles.User1);
+        _profileMock.Setup(p => p.GetUser(It.IsAny<int>())).ReturnsAsync(UserProfiles.User1);
 
         HttpClient client = GetTestClient(_registerMock, _storageMock, _profileMock);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetUserToken(3));
@@ -123,13 +120,9 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         Guid instanceGuid = Guid.NewGuid();
         bool includeParty = false;
 
-        _registerMock.Setup(r =>
-        r.GetParty(It.IsAny<int>()))
-            .ReturnsAsync(Parties.Party1);
+        _registerMock.Setup(r => r.GetParty(It.IsAny<int>())).ReturnsAsync(Parties.Party1);
 
-        _storageMock.Setup(s =>
-        s.GetInstance(It.IsAny<int>(), It.IsAny<Guid>()))
-            .ReturnsAsync(Instances.Instance1);
+        _storageMock.Setup(s => s.GetInstance(It.IsAny<int>(), It.IsAny<Guid>())).ReturnsAsync(Instances.Instance1);
 
         HttpClient client = GetTestClient(_registerMock, _storageMock, _profileMock);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetUserToken(3));
@@ -137,14 +130,16 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         string url = $"{BasePath}instances/{instanceOwnerId}/{instanceGuid}?includeParty={includeParty}";
 
         HttpResponseMessage response = await client.GetAsync(url);
-        ExtendedInstance actual = JsonConvert.DeserializeObject<ExtendedInstance>(await response.Content.ReadAsStringAsync());
+        ExtendedInstance actual = JsonConvert.DeserializeObject<ExtendedInstance>(
+            await response.Content.ReadAsStringAsync()
+        );
 
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
         Assert.Null(actual.Party);
         Assert.NotNull(actual.Instance);
         Assert.Equal("tdd/auth-level-3", actual.Instance.AppId);
     }
-    
+
     [Fact]
     public async Task GetInstanceIncludeParty_TC02_IncludePartyTrue()
     {
@@ -152,13 +147,9 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         Guid instanceGuid = Guid.NewGuid();
         bool includeParty = true;
 
-        _registerMock.Setup(r =>
-        r.GetParty(It.IsAny<int>()))
-            .ReturnsAsync(Parties.Party1);
+        _registerMock.Setup(r => r.GetParty(It.IsAny<int>())).ReturnsAsync(Parties.Party1);
 
-        _storageMock.Setup(s =>
-        s.GetInstance(It.IsAny<int>(), It.IsAny<Guid>()))
-            .ReturnsAsync(Instances.Instance1);
+        _storageMock.Setup(s => s.GetInstance(It.IsAny<int>(), It.IsAny<Guid>())).ReturnsAsync(Instances.Instance1);
 
         HttpClient client = GetTestClient(_registerMock, _storageMock, _profileMock);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetUserToken(3));
@@ -166,7 +157,9 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         string url = $"{BasePath}instances/{instanceOwnerId}/{instanceGuid}?includeParty={includeParty}";
 
         HttpResponseMessage response = await client.GetAsync(url);
-        ExtendedInstance actual = JsonConvert.DeserializeObject<ExtendedInstance>(await response.Content.ReadAsStringAsync());
+        ExtendedInstance actual = JsonConvert.DeserializeObject<ExtendedInstance>(
+            await response.Content.ReadAsStringAsync()
+        );
 
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
         Assert.NotNull(actual.Party);
@@ -181,13 +174,9 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         int instanceOwnerId = 123456;
         Guid instanceGuid = Guid.NewGuid();
 
-        _registerMock.Setup(r =>
-        r.GetParty(It.IsAny<int>()))
-            .ReturnsAsync(Parties.Party1);
+        _registerMock.Setup(r => r.GetParty(It.IsAny<int>())).ReturnsAsync(Parties.Party1);
 
-        _storageMock.Setup(s =>
-        s.GetInstance(It.IsAny<int>(), It.IsAny<Guid>()))
-            .ReturnsAsync(Instances.Instance1);
+        _storageMock.Setup(s => s.GetInstance(It.IsAny<int>(), It.IsAny<Guid>())).ReturnsAsync(Instances.Instance1);
 
         HttpClient client = GetTestClient(_registerMock, _storageMock, _profileMock);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetUserToken(3));
@@ -195,7 +184,9 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         string url = $"{BasePath}instances/{instanceOwnerId}/{instanceGuid}";
 
         HttpResponseMessage response = await client.GetAsync(url);
-        ExtendedInstance actual = JsonConvert.DeserializeObject<ExtendedInstance>(await response.Content.ReadAsStringAsync());
+        ExtendedInstance actual = JsonConvert.DeserializeObject<ExtendedInstance>(
+            await response.Content.ReadAsStringAsync()
+        );
 
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
         Assert.Null(actual.Party);
@@ -209,9 +200,14 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         int instanceOwnerId = 123456;
         Guid instanceGuid = Guid.NewGuid();
 
-        _storageMock.Setup(s =>
-        s.GetInstance(It.IsAny<int>(), It.IsAny<Guid>()))
-            .Throws(new PlatformHttpException(new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.InternalServerError }, string.Empty));
+        _storageMock
+            .Setup(s => s.GetInstance(It.IsAny<int>(), It.IsAny<Guid>()))
+            .Throws(
+                new PlatformHttpException(
+                    new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.InternalServerError },
+                    string.Empty
+                )
+            );
 
         HttpClient client = GetTestClient(_registerMock, _storageMock, _profileMock);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetUserToken(3));
@@ -230,13 +226,16 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         Guid instanceGuid = Guid.NewGuid();
         bool includeParty = true;
 
-        _registerMock.Setup(r =>
-        r.GetParty(It.IsAny<int>()))
-         .Throws(new PlatformHttpException(new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.NotFound }, string.Empty));
+        _registerMock
+            .Setup(r => r.GetParty(It.IsAny<int>()))
+            .Throws(
+                new PlatformHttpException(
+                    new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.NotFound },
+                    string.Empty
+                )
+            );
 
-        _storageMock.Setup(s =>
-        s.GetInstance(It.IsAny<int>(), It.IsAny<Guid>()))
-            .ReturnsAsync(Instances.Instance1);
+        _storageMock.Setup(s => s.GetInstance(It.IsAny<int>(), It.IsAny<Guid>())).ReturnsAsync(Instances.Instance1);
 
         HttpClient client = GetTestClient(_registerMock, _storageMock, _profileMock);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetUserToken(3));
@@ -259,7 +258,8 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
 
         HttpResponseMessage response = await client.GetAsync(url);
         string actual = await response.Content.ReadAsStringAsync();
-        string expected = "{\"attachmentgroupstohide\":\"group.formdatahtml;group.formdatasource;group.signaturesource;group.paymentsource;group.activities\"}";
+        string expected =
+            "{\"attachmentgroupstohide\":\"group.formdatahtml;group.formdatasource;group.signaturesource;group.paymentsource;group.activities\"}";
 
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(expected, actual);
@@ -276,7 +276,9 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         }
 
         claims.Add(new Claim(AltinnCoreClaimTypes.UserName, "UserOne", ClaimValueTypes.String, issuer));
-        claims.Add(new Claim(AltinnCoreClaimTypes.PartyID, (userId + 5000).ToString(), ClaimValueTypes.Integer32, issuer));
+        claims.Add(
+            new Claim(AltinnCoreClaimTypes.PartyID, (userId + 5000).ToString(), ClaimValueTypes.Integer32, issuer)
+        );
         claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticateMethod, "Mock", ClaimValueTypes.String, issuer));
         claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "2", ClaimValueTypes.Integer32, issuer));
 
@@ -288,22 +290,37 @@ public class ReceiptControllerTests : IClassFixture<WebApplicationFactory<Receip
         return token;
     }
 
-    private HttpClient GetTestClient(Mock<IRegister> registerMock, Mock<IStorage> storageMock, Mock<IProfile> profileMock)
+    private HttpClient GetTestClient(
+        Mock<IRegister> registerMock,
+        Mock<IStorage> storageMock,
+        Mock<IProfile> profileMock
+    )
     {
         string projectDir = Directory.GetCurrentDirectory();
         string configPath = Path.Combine($"{projectDir}", "appsettings.json");
 
-        HttpClient client = _factory.WithWebHostBuilder(builder =>
-        {
-            builder.ConfigureTestServices(services =>
-                {
-                    services.AddSingleton(registerMock.Object);
-                    services.AddSingleton(storageMock.Object);
-                    services.AddSingleton(profileMock.Object);
-                    services
-                        .AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
-                }).ConfigureAppConfiguration((context, conf) => { conf.AddJsonFile(configPath); });
-        }).CreateClient();
+        HttpClient client = _factory
+            .WithWebHostBuilder(builder =>
+            {
+                builder
+                    .ConfigureTestServices(services =>
+                    {
+                        services.AddSingleton(registerMock.Object);
+                        services.AddSingleton(storageMock.Object);
+                        services.AddSingleton(profileMock.Object);
+                        services.AddSingleton<
+                            IPostConfigureOptions<JwtCookieOptions>,
+                            JwtCookiePostConfigureOptionsStub
+                        >();
+                    })
+                    .ConfigureAppConfiguration(
+                        (context, conf) =>
+                        {
+                            conf.AddJsonFile(configPath);
+                        }
+                    );
+            })
+            .CreateClient();
 
         return client;
     }

--- a/test/Testdata/Instances.cs
+++ b/test/Testdata/Instances.cs
@@ -1,30 +1,24 @@
 using System;
-
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.Platform.Receipt.Tests.Testdata
 {
     public static class Instances
     {
-        public static Instance Instance1 { get; set; } = new Instance
-        {
-            Id = "1000/1c3a4b9d-cbbe-4146-b370-4164e925812b",
-            InstanceOwner = new InstanceOwner
+        public static Instance Instance1 { get; set; } =
+            new Instance
             {
-                PartyId = Parties.Party1.PartyId.ToString()
-            },
-            AppId = "tdd/auth-level-3",
-            Org = "tdd",
-            Created = DateTime.Parse("2019-07-31T09:57:23.4729995Z"),
-            LastChanged = DateTime.Parse("2019-07-31T09:57:23.4729995Z"),
-            Process = new ProcessState
-            {
-                CurrentTask = new ProcessElementInfo
+                Id = "1000/1c3a4b9d-cbbe-4146-b370-4164e925812b",
+                InstanceOwner = new InstanceOwner { PartyId = Parties.Party1.PartyId.ToString() },
+                AppId = "tdd/auth-level-3",
+                Org = "tdd",
+                Created = DateTime.Parse("2019-07-31T09:57:23.4729995Z"),
+                LastChanged = DateTime.Parse("2019-07-31T09:57:23.4729995Z"),
+                Process = new ProcessState
                 {
-                    ElementId = "FormFilling"
+                    CurrentTask = new ProcessElementInfo { ElementId = "FormFilling" },
+                    Started = DateTime.Parse("2019-07-31T09:57:23.4729995Z"),
                 },
-                Started = DateTime.Parse("2019-07-31T09:57:23.4729995Z")
-            }
-        };
+            };
     }
 }

--- a/test/Testdata/Parties.cs
+++ b/test/Testdata/Parties.cs
@@ -2,13 +2,14 @@ using Altinn.Platform.Register.Models;
 
 namespace Altinn.Platform.Receipt.Tests.Testdata
 {
-   public static class Parties
+    public static class Parties
     {
-        public static Party Party1 { get; set; } = new Party
-        {
-            PartyId = 50001,
-            SSN = "12345678901",
-            PartyTypeName = Register.Enums.PartyType.Person
-        };
+        public static Party Party1 { get; set; } =
+            new Party
+            {
+                PartyId = 50001,
+                SSN = "12345678901",
+                PartyTypeName = Register.Enums.PartyType.Person,
+            };
     }
 }

--- a/test/Testdata/UserProfiles.cs
+++ b/test/Testdata/UserProfiles.cs
@@ -4,14 +4,15 @@ namespace Altinn.Platform.Receipt.Tests.Testdata
 {
     public static class UserProfiles
     {
-        public static UserProfile User1 { get; set; } = new UserProfile
-        {
-            UserId = 1,
-            Email = "test@test.no",
-            PartyId = Parties.Party1.PartyId,
-            PhoneNumber = "98765432",
-            UserType = Profile.Enums.UserType.SelfIdentified,
-            Party = Parties.Party1
-        };
+        public static UserProfile User1 { get; set; } =
+            new UserProfile
+            {
+                UserId = 1,
+                Email = "test@test.no",
+                PartyId = Parties.Party1.PartyId,
+                PhoneNumber = "98765432",
+                UserType = Profile.Enums.UserType.SelfIdentified,
+                Party = Parties.Party1,
+            };
     }
 }


### PR DESCRIPTION
## Description

Adopts [CSharpier](https://csharpier.com/) for code formatting, matching the setup used in [altinn-studio](https://github.com/Altinn/altinn-studio) (the `src/App/backend` implementation).

> [!NOTE]
> **Stacked on #697** (StyleCop removal). This PR is based on the `chore/remove-stylecop` branch, so the diff shows only the CSharpier changes. Merge #697 first, then this — or retarget this PR to `main` once #697 lands. CSharpier's formatting conflicts with several StyleCop `error`-level rules, so the two must not be in the tree together.

## Changes

**Tooling & config**
- `.config/dotnet-tools.json` — pins `csharpier` 1.2.6 as a local dotnet tool (`dotnet tool restore`)
- `.csharpierrc.yaml` — `printWidth: 120`, 4-space indent, `endOfLine: auto` (the altinn-studio convention)
- `.csharpierignore` — excludes `bin/`, `obj/`, `.git/`, and generated/project files
- `Directory.Build.props` — adds `CSharpier.MsBuild` so formatting runs automatically on every build
- `.github/workflows/verify-formatting.yml` — CI job running `dotnet csharpier check .` on PRs
- `.git-blame-ignore-revs` — excludes the bulk-format commit from `git blame`

**Formatting**
- `style: format codebase with csharpier` — applied csharpier across the solution (formatting-only, no behavioral changes; isolated in its own commit and listed in `.git-blame-ignore-revs`)

## Adaptations vs. altinn-studio

altinn-studio is a monorepo with per-project setups; receipt is a single solution, so a few things differ:
- **No `minver`** — receipt doesn't use it for versioning
- **Inline package version** — receipt has no central package management (`Directory.Packages.props`), so `CSharpier.MsBuild` is pinned inline
- **`ubuntu-latest` runner** — studio uses self-hosted runners; adapted to match receipt's existing workflows (dotnet `9.0.x`)
- **No `.vscode/settings.json`** — `.vscode/` is gitignored in this repo (team uses Rider); `CSharpier.MsBuild` covers format-on-build regardless of editor

## Verification

- `dotnet csharpier check .` — clean (33 files)
- `dotnet build Altinn.Receipt.sln` — 0 warnings, 0 errors
- `dotnet test Altinn.Receipt.sln` — 19 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)